### PR TITLE
Display logged in user at top right corner #228

### DIFF
--- a/web/basis/src/main/resources/META-INF/resources/WEB-INF/views/header.jsp
+++ b/web/basis/src/main/resources/META-INF/resources/WEB-INF/views/header.jsp
@@ -53,13 +53,15 @@
                     <li class="header-menu-full-row">
                         <div>
                             <a href="${context}/web/me">
-                                <div class="avatar-username">
-                                </div>
                                 <div class="avatar-circle">
                                     <div class="avatar-inner-circle">
                                         <i class="fas fa-user fa-2x"></i>
                                     </div>
                                 </div>
+                                <div class="avatar-username">
+                                    ${param.loggedInUser}
+                                </div>
+
                             </a>
                         </div>
                     </li>

--- a/web/basis/src/main/resources/META-INF/resources/WEB-INF/views/index.jsp
+++ b/web/basis/src/main/resources/META-INF/resources/WEB-INF/views/index.jsp
@@ -33,7 +33,9 @@
       <script type="text/javascript" charset="UTF-8" src="<c:url value="/resources/js/demoMode.js"/>"></script>
   </head>
     <body>
-        <jsp:include page="header.jsp" />
+        <jsp:include page="header.jsp" >
+            <jsp:param name="loggedInUser" value="${loggedInUser}" />
+        </jsp:include>
         <jsp:include page="menu.jsp" />
         <jsp:include page="${partial}" />
         <jsp:include page="footer.jsp" />

--- a/web/basis/src/main/resources/META-INF/resources/resources/css/header.scss
+++ b/web/basis/src/main/resources/META-INF/resources/resources/css/header.scss
@@ -153,7 +153,7 @@
     border-radius: 50%;
     -webkit-border-radius: 50%;
     -moz-border-radius: 50%;
-    margin-top: 9px;
+    margin-top: 3px;
     margin-right: 10px;
     padding-top: 3px;
     padding-left: 3px;

--- a/web/basis/src/main/resources/META-INF/resources/resources/css/main-stylesheet.css
+++ b/web/basis/src/main/resources/META-INF/resources/resources/css/main-stylesheet.css
@@ -252,7 +252,7 @@ a {
     border-radius: 50%;
     -webkit-border-radius: 50%;
     -moz-border-radius: 50%;
-    margin-top: 9px;
+    margin-top: 3px;
     margin-right: 10px;
     padding-top: 3px;
     padding-left: 3px;


### PR DESCRIPTION
Fixes #228

Now its showing logged in user below avatar at the top right corner, as shown on image.

![loggedInUser](https://user-images.githubusercontent.com/20339349/83356461-a47f0180-a366-11ea-8fb2-768b97e3f06c.PNG)



