### PR TITLE
Configuring soap address location in WSDL

### DIFF
--- a/web/mock/soap/src/main/java/com/castlemock/web/mock/soap/utility/config/AddressLocationConfigurer.java
+++ b/web/mock/soap/src/main/java/com/castlemock/web/mock/soap/utility/config/AddressLocationConfigurer.java
@@ -1,0 +1,23 @@
+package com.castlemock.web.mock.soap.utility.config;
+
+public class AddressLocationConfigurer {
+	
+	public String configureAddressLocation(String wsdl, String correctAddressLocation) {
+		final String adressLocationTag = "<soap:address location=\"";
+		final int beginIndexAdressLocationTag = wsdl.indexOf(adressLocationTag);
+		if (beginIndexAdressLocationTag >= 0) {
+			final int beginIndexUrl = beginIndexAdressLocationTag + adressLocationTag.length();
+			final int endIndexUrl = wsdl.indexOf("\"", beginIndexUrl);
+			
+			StringBuilder wsdlBuilder = new StringBuilder();
+			wsdlBuilder.append(wsdl.substring(0, beginIndexUrl));
+			wsdlBuilder.append(correctAddressLocation);
+			wsdlBuilder.append(wsdl.substring(endIndexUrl));
+			
+			return wsdlBuilder.toString();			
+		} else {
+			return wsdl;
+		}
+	}
+
+}

--- a/web/mock/soap/src/main/java/com/castlemock/web/mock/soap/web/soap/controller/AbstractSoapServiceController.java
+++ b/web/mock/soap/src/main/java/com/castlemock/web/mock/soap/web/soap/controller/AbstractSoapServiceController.java
@@ -55,6 +55,7 @@ import com.castlemock.web.mock.soap.model.SoapException;
 import com.castlemock.web.mock.soap.support.MtomUtility;
 import com.castlemock.web.mock.soap.support.SoapUtility;
 import com.castlemock.web.mock.soap.utility.compare.SoapMockResponseNameComparator;
+import com.castlemock.web.mock.soap.utility.config.AddressLocationConfigurer;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -142,7 +143,9 @@ public abstract class AbstractSoapServiceController extends AbstractController{
             while(parameterNames.hasMoreElements()){
                 String parameterName = parameterNames.nextElement();
                 if(parameterName.equalsIgnoreCase("wsdl")){
-                    final String wsdl = getWsdl(projectId);
+                    String wsdl = getWsdl(projectId);
+                    
+                    wsdl = new AddressLocationConfigurer().configureAddressLocation(wsdl, httpServletRequest.getRequestURL().toString());
 
                     final HttpHeaders responseHeaders = new HttpHeaders();
                     responseHeaders.put(CONTENT_TYPE, ImmutableList.of("text/xml; " + DEFAULT_CHAR_SET));

--- a/web/mock/soap/src/test/java/com/castlemock/web/mock/soap/utility/config/AddressLocationConfigurerTest.java
+++ b/web/mock/soap/src/test/java/com/castlemock/web/mock/soap/utility/config/AddressLocationConfigurerTest.java
@@ -1,0 +1,43 @@
+package com.castlemock.web.mock.soap.utility.config;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AddressLocationConfigurerTest {
+	
+	private static final String WSDL_WITHOU_ADDRESS_LOCATION = "<wsdl:definitions>\n" +
+			"  <wsdl:service name=\"Service\">\n" + 
+			"    <wsdl:port name=\"ServiceHttpPost\" binding=\"tns:ServiceHttpPost\">\n" +
+			"    </wsdl:port>\n" + 
+			"  </wsdl:service>\n" +
+			"</wsdl:definitions>";
+	
+	private static final String ORIGINAL_WSDL_WITH_ADDRESS_LOCATION = "<wsdl:definitions>\n" +
+			"  <wsdl:service name=\"Service\">\n" + 
+			"    <wsdl:port name=\"ServiceHttpPost\" binding=\"tns:ServiceHttpPost\">\n" +
+			"      <soap:address location=\"http://www.castlemock.com/services/myservice\"/>\n" + 
+			"    </wsdl:port>\n" + 
+			"  </wsdl:service>\n" +
+			"</wsdl:definitions>";
+	
+	private static final String MODIFIED_WSDL_WITH_ADDRESS_LOCATION = "<wsdl:definitions>\n" +
+			"  <wsdl:service name=\"Service\">\n" + 
+			"    <wsdl:port name=\"ServiceHttpPost\" binding=\"tns:ServiceHttpPost\">\n" +
+			"      <soap:address location=\"http://localhost:8080/other-path\"/>\n" + 
+			"    </wsdl:port>\n" + 
+			"  </wsdl:service>\n" +
+			"</wsdl:definitions>";
+
+	@Test
+	public void testWsdlWithAddressLocation() {
+		String wsdlModified = new AddressLocationConfigurer().configureAddressLocation(ORIGINAL_WSDL_WITH_ADDRESS_LOCATION, "http://localhost:8080/other-path");
+		Assert.assertEquals(MODIFIED_WSDL_WITH_ADDRESS_LOCATION, wsdlModified);
+	}
+	
+	@Test
+	public void testWsdlWithoutAddressLocation() {
+		String wsdlResult = new AddressLocationConfigurer().configureAddressLocation(WSDL_WITHOU_ADDRESS_LOCATION, "http://localhost:8080/other-path");
+		Assert.assertEquals(WSDL_WITHOU_ADDRESS_LOCATION, wsdlResult);
+	}
+
+}

--- a/web/mock/soap/src/test/java/com/castlemock/web/mock/soap/web/soap/controller/SoapServiceControllerTest.java
+++ b/web/mock/soap/src/test/java/com/castlemock/web/mock/soap/web/soap/controller/SoapServiceControllerTest.java
@@ -386,6 +386,8 @@ public class SoapServiceControllerTest extends AbstractControllerTest {
     public void testGetWsdl(){
         final HttpServletRequest httpServletRequest = getMockedHttpServletRequest("");
         when(httpServletRequest.getParameterNames()).thenReturn(Collections.enumeration(Collections.singletonList("wsdl")));
+        when(httpServletRequest.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080" + CONTEXT + SLASH + MOCK + SLASH + SOAP +
+        		SLASH + PROJECT + SLASH + PROJECT_ID + SLASH + SOAP_PORT_ID));
 
         final SoapProject soapProject = getSoapProject();
         final ReadSoapProjectOutput readSoapProjectOutput = ReadSoapProjectOutput.builder()
@@ -409,6 +411,8 @@ public class SoapServiceControllerTest extends AbstractControllerTest {
     public void testGetWsdlWildcard() {
         final HttpServletRequest httpServletRequest = getMockedHttpServletRequest("");
         when(httpServletRequest.getParameterNames()).thenReturn(Collections.enumeration(Collections.singletonList("wsdl")));
+        when(httpServletRequest.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080" + CONTEXT + SLASH + MOCK + SLASH + SOAP +
+        		SLASH + PROJECT + SLASH + PROJECT_ID + SLASH + SOAP_PORT_ID));
 
         final SoapProject soapProject = getSoapProject();
         final ReadSoapProjectOutput readSoapProjectOutput = ReadSoapProjectOutput.builder()


### PR DESCRIPTION
This resolve [issue 192](https://github.com/castlemock/castlemock/issues/192) by modify WSDL content before returning it when consumer call WSDL URL.
The address location will the WSDL URL without `?wsdl` sufix.

**Example**
1. Given stored this WSDL with addess location as `http://www.castlemock.com/services/myservice`
```wsdl
<wsdl:definitions>
  <wsdl:service name="Service"> 
    <wsdl:port name="ServiceHttpPost" binding="tns:ServiceHttpPost">
      <soap:address location="http://www.castlemock.com/services/myservice"/> 
    </wsdl:port> 
  </wsdl:service>
</wsdl:definitions>
```
2. When consumer open URL `http://localhost:8080/castlemock/mock/soap/project/twFGec/ServiceHttpPost?wsdl` will return content with modified address location to `http://localhost:8080/castlemock/mock/soap/project/twFGec/ServiceHttpPost`
```wsdl
<wsdl:definitions>
  <wsdl:service name="Service"> 
    <wsdl:port name="ServiceHttpPost" binding="tns:ServiceHttpPost">
      <soap:address location="http://localhost:8080/castlemock/mock/soap/project/twFGec/ServiceHttpPost"/> 
    </wsdl:port> 
  </wsdl:service>
</wsdl:definitions>
```
3. When client open URL `http://my-host/castlemock/mock/soap/project/twFGec/ServiceHttpPost?wsdl` will return content with modified address location to `http://my-host/castlemock/mock/soap/project/twFGec/ServiceHttpPost`
```wsdl
<wsdl:definitions>
  <wsdl:service name="Service"> 
    <wsdl:port name="ServiceHttpPost" binding="tns:ServiceHttpPost">
      <soap:address location="http://my-host/castlemock/mock/soap/project/twFGec/ServiceHttpPost"/> 
    </wsdl:port> 
  </wsdl:service>
</wsdl:definitions>
```
**Another cases**
1. WSDL without address location will returned as is
2. For WSDL with more then one `<soap:address location`, only the first will modified and the another will returned as is
