### PR TITLE
Add Faker expression

### DIFF
--- a/core/basis/pom.xml
+++ b/core/basis/pom.xml
@@ -41,6 +41,14 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
         </dependency>
+        <dependency>
+		    <groupId>com.github.javafaker</groupId>
+		    <artifactId>javafaker</artifactId>
+		</dependency>
+		<dependency>
+		    <groupId>org.springframework</groupId>
+		    <artifactId>spring-expression</artifactId>
+		</dependency>
     </dependencies>
 
     <build>

--- a/core/basis/src/main/java/com/castlemock/core/basis/utility/parser/TextParser.java
+++ b/core/basis/src/main/java/com/castlemock/core/basis/utility/parser/TextParser.java
@@ -61,6 +61,7 @@ public class TextParser {
         EXPRESSIONS.put(BodyJsonPathExpression.IDENTIFIER, new BodyJsonPathExpression());
         EXPRESSIONS.put(UrlHostExpression.IDENTIFIER, new UrlHostExpression());
         EXPRESSIONS.put(BodyXPathExpression.IDENTIFIER, new BodyXPathExpression());
+        EXPRESSIONS.put(FakerExpression.IDENTIFIER, new FakerExpression());
     }
 
     /**

--- a/core/basis/src/main/java/com/castlemock/core/basis/utility/parser/expression/FakerExpression.java
+++ b/core/basis/src/main/java/com/castlemock/core/basis/utility/parser/expression/FakerExpression.java
@@ -1,0 +1,99 @@
+package com.castlemock.core.basis.utility.parser.expression;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import com.castlemock.core.basis.utility.parser.expression.argument.ExpressionArgument;
+import com.castlemock.core.basis.utility.parser.expression.argument.ExpressionArgumentString;
+import com.github.javafaker.Faker;
+
+/**
+ * {@link FakerExpression} is an {@link Expression} and will call {@link Faker}
+ * methods api to transform an matching input string to a fake string.
+ */
+public class FakerExpression extends AbstractExpression {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(FakerExpression.class);
+
+	public static final String IDENTIFIER = "FAKER";
+	public static final String API_ARGUMENT = "api";
+	public static final String LOCALE_ARGUMENT = "locale";
+	private final Map<String, Faker> fakerByLocale = new HashMap<>();
+
+	/**
+	 * Will transform the provided <code>input</code> to a fake string. The implementation use 
+	 * Spring Expression Language (SpEL) to call {@link Faker} methods api.
+	 *
+	 * @param input The input string that will be transformed.
+	 * @return A transformed <code>input</code>.
+	 * 
+	 * @see https://docs.spring.io/spring/docs/5.2.x/spring-framework-reference/core.html#expressions
+	 * @see https://github.com/DiUS/java-faker
+	 */
+	@Override
+	public String transform(ExpressionInput input) {
+		final ExpressionArgument<?> apiArgument = input.getArgument(API_ARGUMENT);
+		final ExpressionArgument<?> localeArgument = input.getArgument(LOCALE_ARGUMENT);
+
+		try {
+			Faker faker = getFaker(getLocaleLanguageTag(localeArgument));
+			String springExpression = getApiArgumentString(apiArgument);
+
+			org.springframework.expression.ExpressionParser parser = new SpelExpressionParser();
+			org.springframework.expression.Expression exp = parser.parseExpression(springExpression);
+			org.springframework.expression.EvaluationContext context = new StandardEvaluationContext(faker);
+
+			Object result = exp.getValue(context);
+
+			if (result != null) {
+				return String.valueOf(result);
+			}
+		} catch (Exception e) {
+			LOGGER.warn("Can not transform ${FAKER(api=\"" + apiArgument.getValue() + "\", locale=\""
+					+ localeArgument.getValue() + "\")", e);
+		}
+
+		return "";
+	}
+
+	@Override
+	public boolean match(String input) {
+		return IDENTIFIER.equalsIgnoreCase(input);
+	}
+
+	private Faker getFaker(final String localeLanguageTag) {
+		if (!fakerByLocale.containsKey(localeLanguageTag)) {
+			fakerByLocale.put(localeLanguageTag, createFaker(localeLanguageTag));
+		}
+
+		return fakerByLocale.get(localeLanguageTag);
+	}
+
+	private Faker createFaker(final String localeLanguageTag) {
+		if (localeLanguageTag == null) {
+			return new Faker();
+		}
+		return new Faker(Locale.forLanguageTag(localeLanguageTag));
+	}
+
+	private String getLocaleLanguageTag(final ExpressionArgument<?> localeArgument) {
+		if (localeArgument instanceof ExpressionArgumentString) {
+			return ((ExpressionArgumentString) localeArgument).getValue();
+		}
+		return null;
+	}
+
+	private String getApiArgumentString(final ExpressionArgument<?> apiArgument) {
+		if (apiArgument instanceof ExpressionArgumentString) {
+			return ((ExpressionArgumentString) apiArgument).getValue();
+		}
+		return null;
+	}
+
+}

--- a/core/basis/src/test/java/com/castlemock/core/basis/utility/parser/FakerExpressionTest.java
+++ b/core/basis/src/test/java/com/castlemock/core/basis/utility/parser/FakerExpressionTest.java
@@ -1,0 +1,104 @@
+package com.castlemock.core.basis.utility.parser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import com.castlemock.core.basis.utility.parser.expression.ExpressionInput;
+import com.castlemock.core.basis.utility.parser.expression.FakerExpression;
+import com.castlemock.core.basis.utility.parser.expression.argument.ExpressionArgumentString;
+
+public class FakerExpressionTest {
+
+	private final FakerExpression fakerExpression = new FakerExpression();
+
+	@Test
+	public void testMatch() {
+		assertTrue(fakerExpression.match("FAKER"));
+		assertTrue(fakerExpression.match("faker"));
+	}
+	
+	@Test
+	public void testWithoutParams() {
+		String result = fakerExpression.transform(createExpressionInput("name().fullName()"));
+		assertNotNull(result);
+		assertTrue(result.length() > 0);
+	}
+
+	@Test
+	public void testWithParamsInt() {
+		String result = fakerExpression.transform(createExpressionInput("number().numberBetween(1, 2)"));
+		assertTrue(Arrays.asList("1", "2").contains(result));
+	}
+
+	@Test
+	public void testWithParamsLong() {
+		String result = fakerExpression
+				.transform(createExpressionInput("number().numberBetween(2147483647000L, 2147483647001L)"));
+		assertTrue(Arrays.asList("2147483647000", "2147483647001").contains(result));
+	}
+
+	@Test
+	public void testWithParamsDouble() {
+		String result = fakerExpression.transform(createExpressionInput("commerce().price(10.5, 1000.29)"));
+		Double resultDouble = Double.valueOf(result);
+		assertTrue(resultDouble >= 10.5 && resultDouble <= 1000.29);
+	}
+
+	@Test
+	public void testWithParamBoolean() {
+		String result = fakerExpression.transform(createExpressionInput("address().streetAddress(true)"));
+		assertTrue(result.length() > 0);
+	}
+
+	@Test
+	public void testWithParamString() {
+		String result = fakerExpression.transform(createExpressionInput("address().zipCodeByState('FL')"));
+		assertTrue(result.length() > 0);
+	}
+
+	@Test
+	public void testWithParamEnumAndDate() {
+		String fakerApi = "date().future(7, T(java.util.concurrent.TimeUnit).DAYS, new java.util.Date())";
+		String springExpression = "new java.text.SimpleDateFormat(\"YYYY-MM-dd\").format(" + fakerApi + ")";
+		String result = fakerExpression.transform(createExpressionInput(springExpression));
+		assertTrue(result.length() > 0);
+	}
+	
+	@Test
+	public void testLocale() {
+		String result = fakerExpression.transform(createExpressionInput("name().fullName()", "pt-BR"));
+		assertNotNull(result);
+		assertTrue(result.length() > 0);
+	}
+	
+	@Test
+	public void testInvalidLocale() {
+		String result = fakerExpression.transform(createExpressionInput("name().fullName()", "invalidLocale"));
+		assertEquals("", result);
+	}
+	
+	@Test
+	public void testInvalidApi() {
+		String result = fakerExpression.transform(createExpressionInput("notExisting().notExisting()"));
+		assertEquals("", result);
+	}
+
+	private ExpressionInput createExpressionInput(String argumentApiValue) {
+		return createExpressionInput(argumentApiValue, null);
+	}
+	
+	private ExpressionInput createExpressionInput(String argumentApiValue, String argumentLocaleValue) {
+		final ExpressionInput expressionInput = new ExpressionInput(FakerExpression.IDENTIFIER);
+		expressionInput.addArgument(FakerExpression.API_ARGUMENT, new ExpressionArgumentString(argumentApiValue));
+		if (argumentApiValue != null) {
+			expressionInput.addArgument(FakerExpression.LOCALE_ARGUMENT, new ExpressionArgumentString(argumentLocaleValue));	
+		}
+		return expressionInput;
+	}
+
+}

--- a/core/basis/src/test/java/com/castlemock/core/basis/utility/parser/TextParserTest.java
+++ b/core/basis/src/test/java/com/castlemock/core/basis/utility/parser/TextParserTest.java
@@ -64,5 +64,13 @@ public class TextParserTest {
         Assert.assertNotEquals(input, output);
         Assert.assertTrue(output.matches("Hello this is a (.*?)."));
     }
+    
+    @Test
+    public void testParseFaker(){
+        String input = "Hello this is a ${FAKER(api=\"name().fullName()\")}.";
+        String output = TextParser.parse(input);
+        Assert.assertNotEquals(input, output);
+        Assert.assertTrue(output.matches("Hello this is a (.*?)."));
+    }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <springfox.version>2.9.2</springfox.version>
         <maven.jar.version>3.1.1</maven.jar.version>
         <json.path.version>2.4.0</json.path.version>
+        <javafaker.version>1.0.2</javafaker.version>
         <joda.time.version>2.10.6</joda.time.version>
         <activation.version>1.1.1</activation.version>
         <bytebuddy.version>1.10.10</bytebuddy.version>
@@ -298,6 +299,11 @@
                 <version>${spring.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-expression</artifactId>
+                <version>${spring.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-security</artifactId>
                 <version>${spring.boot.version}</version>
@@ -411,6 +417,11 @@
                 <artifactId>json-path</artifactId>
                 <version>${json.path.version}</version>
             </dependency>
+            <dependency>
+			    <groupId>com.github.javafaker</groupId>
+			    <artifactId>javafaker</artifactId>
+			    <version>${javafaker.version}</version>
+			</dependency>
             <dependency>
                 <groupId>javax.activation</groupId>
                 <artifactId>activation</artifactId>


### PR DESCRIPTION
This Pull Request add faker expression that transform inputs using [Java Faker](https://github.com/DiUS/java-faker).

[Java Faker](https://github.com/DiUS/java-faker) library is a port of Ruby's [faker](https://github.com/stympy/faker) gem (as well as Perl's Data::Faker library) that generates fake data. It's useful when you're developing a new project and need some pretty data for showcase.

If this Pull Request was accepted, will be need to update castlemock [Expressions Page](https://github.com/castlemock/castlemock/wiki/Expression) in castlemock Github Wiki.

Sugestion content for the Wiki
---
## Faker
Transform an matching input string to a fake string.

Arguments:

- **api:** the [Faker](https://github.com/DiUS/java-faker/blob/master/src/main/java/com/github/javafaker/Faker.java) api methods used to transform. This is a [Spring Expression Language (SpEL)](https://docs.spring.io/spring/docs/5.2.x/spring-framework-reference/core.html#expressions) with a [Faker](https://github.com/DiUS/java-faker/blob/master/src/main/java/com/github/javafaker/Faker.java) instance as the root object used to evaluate an expression. For example, `name().fullName()` is equivalent to `new Faker().name().fullName()`.

- **locale:** one of the [Java Faker supported locales](https://github.com/DiUS/java-faker#supported-locales) used to instanciate [Faker](https://github.com/DiUS/java-faker/blob/master/src/main/java/com/github/javafaker/Faker.java) class. This argument is optional, and if omited `"en"` is used by default.

### Examples:

#### With and without locale
```
${FAKER(api="name().fullName()")}
${FAKER(api="name().fullName()", locale="pt-BR")}
${FAKER(api="name().fullName()", locale="ja")}
```
#### Some valid expressions
`${FAKER(api="name().firstName()")}`
`${FAKER(api="number().numberBetween(1, 2)")}` - params int
`${FAKER(api="number().numberBetween(2147483647000L, 2147483647001L)")}` - params long with L suffix
`${FAKER(api="commerce().price(10.5, 1000.29)")}` - params double
`${FAKER(api="address().streetAddress(true)")}` - params boolean
`${FAKER(api="address().zipCodeByState('FL')")}` - param String

#### Advanced expression using SimpleDateFormat, enum and Date
`${FAKER(api="new java.text.SimpleDateFormat('YYYY-MM-dd').format(date().future(7, T(java.util.concurrent.TimeUnit).DAYS, new java.util.Date()))")}`

This expression is equivalent to
```java
Date future = new Faker().date().future(7, TimeUnit.DAYS, new Date());
String result = new java.text.SimpleDateFormat("YYYY-MM-dd").format(future);
```