### PR TITLE
Correct InvokeAddress

### DIFF
--- a/web/basis/src/main/java/com/castlemock/web/basis/utility/BaseUrlInfo.java
+++ b/web/basis/src/main/java/com/castlemock/web/basis/utility/BaseUrlInfo.java
@@ -1,0 +1,141 @@
+package com.castlemock.web.basis.utility;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class BaseUrlInfo {
+
+	private final String protocol;
+	private final String serverName;
+	private final int serverPort;
+	private final String contextPath;
+	private final String serverUrl;
+	private final String baseUrl;
+
+	public BaseUrlInfo(final String protocol, final String serverName, int serverPort, final String contextPath) {
+		this.protocol = protocol;
+		this.serverName = serverName;
+		this.serverPort = serverPort;
+		this.contextPath = contextPath;
+		this.serverUrl = buildServerUrl(protocol, serverName, serverPort);
+		this.baseUrl = new StringBuilder().append(this.serverUrl).append(contextPath).toString();
+	}
+
+	private String buildServerUrl(String protocol, String hostname, int port) {
+		StringBuilder baseUrl = new StringBuilder();
+		baseUrl.append(protocol).append("://").append(hostname);
+		if (port != 80 && port != 443) {
+			baseUrl.append(':').append(port);
+		}
+		return baseUrl.toString();
+	}
+
+	public static Builder builder(final HttpServletRequest request) {
+		return new Builder(request);
+	}
+
+	/**
+	 * Returns the name of the protocol used to make this request, http or https.
+     * 
+	 * @return a String containing the name of the protocol used to make this request
+	 */
+	public String getProtocol() {
+		return protocol;
+	}
+
+	/**
+	 * Returns the host name of the server to which the request was sent. It is the value of the part before ":" in the Host header value,
+	 * if any, or the resolved server name, or the server IP address.
+	 * 
+	 * @return a String containing the name of the server
+	 */
+	public String getServerName() {
+		return serverName;
+	}
+
+	/**
+	 * Returns the port number to which the request was sent. It is the value of the part after ":" in the Host header value,
+	 * if any, or the server port where the client connection was accepted on.
+	 * 
+	 * @return an integer specifying the port number
+	 */
+	public int getServerPort() {
+		return serverPort;
+	}
+
+	/**
+     * Returns the current application context path. For example the /castlemock in http://localhost:8080/castlemock
+     * @return The current application context path
+     */
+	public String getContextPath() {
+		return contextPath;
+	}
+
+	/**
+	 * Returns the server url, without the application context path. For example http://localhost:8080 or https://www.castlemock.com
+	 * 
+	 * @return The application server url
+	 */
+
+	public String getServerUrl() {
+		return serverUrl;
+	}
+
+	/**
+	 * Returns the application base url, with the application context path, if any. For example http://localhost:8080/castlemock or https://www.castlemock.com/castlemock
+	 * 
+	 * @return The application base url
+	 */
+	public String getBaseUrl() {
+		return baseUrl;
+	}
+	
+	@Override
+	public String toString() {
+		return "BaseUrlInfo{protocol=" + protocol + ", serverName=" + serverName + ", serverPort=" + serverPort
+				+ ", contextPath=" + contextPath + ", serverUrl=" + serverUrl + ", baseUrl=" + baseUrl + "}";
+	}
+
+
+
+	public static final class Builder {
+		private final HttpServletRequest request;
+		private String preferedServerName;
+
+		private Builder(final HttpServletRequest request) {
+			this.request = request;
+		}
+
+		/**
+		 * If <code>preferedServerName</code> is non-null and non-empty, it will be used as the server name.
+         * Otherwise, the server name will be obtained from </code>request.getServerName()</code>
+         * 
+		 * @param preferedServerName the server name to be used, if non-null and non-empty. 
+		 * @return The {@link Builder} instance  
+		 */
+		public Builder preferedServerName(final String preferedServerName) {
+			this.preferedServerName = preferedServerName;
+			return this;
+		}
+
+		public BaseUrlInfo build() {
+			return new BaseUrlInfo(determineProtocol(), determineServerName(), request.getServerPort(), request.getContextPath());
+		}
+
+		private String determineProtocol() {
+			Object xForwardedProto = this.request.getHeader("X-Forwarded-Proto");
+			if (xForwardedProto != null) {
+				return xForwardedProto.toString();
+			}
+			return this.request.getScheme();
+		}
+
+		private String determineServerName() {
+			if (preferedServerName != null && !preferedServerName.isEmpty()) {
+				return preferedServerName;
+			}
+			return request.getServerName();
+		}
+
+	}
+
+}

--- a/web/basis/src/main/java/com/castlemock/web/basis/web/AbstractController.java
+++ b/web/basis/src/main/java/com/castlemock/web/basis/web/AbstractController.java
@@ -18,17 +18,15 @@ package com.castlemock.web.basis.web;
 
 import com.castlemock.core.basis.model.ServiceProcessor;
 import com.castlemock.core.basis.model.user.domain.User;
+import com.castlemock.web.basis.utility.BaseUrlInfo;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import javax.servlet.ServletContext;
-import java.net.Inet4Address;
-import java.net.InetAddress;
-import java.net.NetworkInterface;
-import java.net.SocketException;
-import java.util.Enumeration;
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * The AbstractController provides functionality that are shared among all the controllers in Castle Mock
@@ -66,12 +64,9 @@ public abstract class AbstractController {
     protected static final String USERS = "users";
     protected static final String USER_STATUSES = "userStatuses";
     protected static final String FILE_UPLOAD_FORM = "uploadForm";
-    protected static final String HTTP = "http://";
-    protected static final String HTTPS = "https://";
 
     protected static final int DEFAULT_ECHO_RESPONSE_CODE = 200;
 
-    private static final String LOCAL_ADDRESS = "127.0.0.1";
     private static final String ANONYMOUS_USER = "Anonymous";
     /**
      * Returns the current application context for Castle Mock. For example the /castlemock in http://localhost:8080/castlemock
@@ -95,32 +90,12 @@ public abstract class AbstractController {
     }
 
     /**
-     * The method returns the local address (Not link local address, not loopback address) which the server is deployed on.
-     * If the method does not find any INet4Address that is neither link local address and loopback address, the method
-     * will return the the address 127.0.0.1
-     * @return Returns the local address or 127.0.0.1 if no address was found
-     * @throws SocketException Upon failing to extract network interfaces
+     * Return the BaseUrlInfo based on request and endpointAddress.
+     * @param request The HttpServletRequest instance.
+     * @return BaseUrlInfo
      */
-    public String getHostAddress() throws SocketException {
-        if(endpointAddress != null && !endpointAddress.isEmpty()){
-            return endpointAddress;
-        }
-
-        final Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
-        while (networkInterfaces.hasMoreElements())
-        {
-            final NetworkInterface networkInterface = networkInterfaces.nextElement();
-            final Enumeration<InetAddress> addresses = networkInterface.getInetAddresses();
-            while (addresses.hasMoreElements())
-            {
-                final InetAddress address = addresses.nextElement();
-                if (!address.isLinkLocalAddress() && !address.isLoopbackAddress() && address instanceof Inet4Address){
-                    return address.getHostAddress();
-                }
-            }
-        }
-
-        return LOCAL_ADDRESS;
+    public BaseUrlInfo getBaseUrlInfo(final HttpServletRequest request) {
+    	return BaseUrlInfo.builder(request).preferedServerName(endpointAddress).build();
     }
 
 }

--- a/web/basis/src/main/java/com/castlemock/web/basis/web/view/controller/AbstractViewController.java
+++ b/web/basis/src/main/java/com/castlemock/web/basis/web/view/controller/AbstractViewController.java
@@ -145,13 +145,4 @@ public abstract class AbstractViewController extends AbstractController {
         return !(auth instanceof AnonymousAuthenticationToken);
     }
 
-    /**
-     * The method indicates which protocol is used for the incoming request: HTTP or HTTPS
-     * @param request The request is used to determine the protocol
-     * @return HTTP is returned if the request is not secured. HTTPS is returned if the request is secured.
-     */
-    protected String getProtocol(final ServletRequest request){
-        return request.isSecure() ? HTTPS : HTTP;
-    }
-
 }

--- a/web/basis/src/test/java/com/castlemock/web/basis/utility/BaseUrlInfoTest.java
+++ b/web/basis/src/test/java/com/castlemock/web/basis/utility/BaseUrlInfoTest.java
@@ -1,0 +1,86 @@
+package com.castlemock.web.basis.utility;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class BaseUrlInfoTest {
+
+	@Test
+	public void testBuildUrl() {
+		final HttpServletRequest httpServletRequest = mockHttpServletRequest("http", "localhost", 8080, "/castlemock");
+		BaseUrlInfo baseUrlInfo = BaseUrlInfo.builder(httpServletRequest).build();
+
+		Assert.assertEquals("http", baseUrlInfo.getProtocol());
+		Assert.assertEquals("localhost", baseUrlInfo.getServerName());
+		Assert.assertEquals(8080, baseUrlInfo.getServerPort());
+		Assert.assertEquals("/castlemock", baseUrlInfo.getContextPath());
+		Assert.assertEquals("http://localhost:8080", baseUrlInfo.getServerUrl());
+		Assert.assertEquals("http://localhost:8080/castlemock", baseUrlInfo.getBaseUrl());
+	}
+
+	@Test
+	public void testShouldNotAppendPort80OnUrl() {
+		final HttpServletRequest httpServletRequest = mockHttpServletRequest("http", "www.castlemock.com", 80, "/castlemock");
+		final BaseUrlInfo baseUrlInfo = BaseUrlInfo.builder(httpServletRequest).build();
+		
+		Assert.assertEquals("http", baseUrlInfo.getProtocol());
+		Assert.assertEquals("www.castlemock.com", baseUrlInfo.getServerName());
+		Assert.assertEquals(80, baseUrlInfo.getServerPort());
+		Assert.assertEquals("/castlemock", baseUrlInfo.getContextPath());
+		Assert.assertEquals("http://www.castlemock.com", baseUrlInfo.getServerUrl());
+		Assert.assertEquals("http://www.castlemock.com/castlemock", baseUrlInfo.getBaseUrl());
+	}
+
+	@Test
+	public void testShouldNotAppendPort443OnUrl() {
+		final HttpServletRequest httpServletRequest = mockHttpServletRequest("https", "www.castlemock.com", 443, "/castlemock");
+		BaseUrlInfo baseUrlInfo = BaseUrlInfo.builder(httpServletRequest).build();
+
+		Assert.assertEquals("https", baseUrlInfo.getProtocol());
+		Assert.assertEquals("www.castlemock.com", baseUrlInfo.getServerName());
+		Assert.assertEquals(443, baseUrlInfo.getServerPort());
+		Assert.assertEquals("/castlemock", baseUrlInfo.getContextPath());
+		Assert.assertEquals("https://www.castlemock.com", baseUrlInfo.getServerUrl());
+		Assert.assertEquals("https://www.castlemock.com/castlemock", baseUrlInfo.getBaseUrl());
+	}
+	
+	@Test
+	public void testPreferedServerName() {
+		final HttpServletRequest httpServletRequest = mockHttpServletRequest("http", "localhost", 8080, "/castlemock");
+		BaseUrlInfo baseUrlInfo = BaseUrlInfo.builder(httpServletRequest).preferedServerName("my-prefered-server-name").build();
+
+		Assert.assertEquals("http", baseUrlInfo.getProtocol());
+		Assert.assertEquals("my-prefered-server-name", baseUrlInfo.getServerName());
+		Assert.assertEquals(8080, baseUrlInfo.getServerPort());
+		Assert.assertEquals("/castlemock", baseUrlInfo.getContextPath());
+		Assert.assertEquals("http://my-prefered-server-name:8080", baseUrlInfo.getServerUrl());
+		Assert.assertEquals("http://my-prefered-server-name:8080/castlemock", baseUrlInfo.getBaseUrl());
+	}
+	
+
+	@Test
+	public void givenXForwardedProtoEqualhttps_schemaEqualHttp_shouldReturnProtocolhttps() {
+		final HttpServletRequest httpServletRequest = mockHttpServletRequest("http", "www.castlemock.com", 443, "/castlemock");
+		Mockito.when(httpServletRequest.getHeader("X-Forwarded-Proto")).thenReturn("https");
+		
+		BaseUrlInfo baseUrlInfo = BaseUrlInfo.builder(httpServletRequest).build();
+
+		Assert.assertEquals("https", baseUrlInfo.getProtocol());
+		Assert.assertEquals("https://www.castlemock.com", baseUrlInfo.getServerUrl());
+		Assert.assertEquals("https://www.castlemock.com/castlemock", baseUrlInfo.getBaseUrl());
+	}
+
+	private HttpServletRequest mockHttpServletRequest(final String protocol, final String serverName,
+			final int serverPort, final String contextPath) {
+		final HttpServletRequest httpServletRequest = Mockito.mock(HttpServletRequest.class);
+		Mockito.when(httpServletRequest.getScheme()).thenReturn(protocol);
+		Mockito.when(httpServletRequest.getServerName()).thenReturn(serverName);
+		Mockito.when(httpServletRequest.getServerPort()).thenReturn(serverPort);
+		Mockito.when(httpServletRequest.getContextPath()).thenReturn(contextPath);
+		return httpServletRequest;
+	}
+
+}

--- a/web/mock/graphql/src/main/java/com/castlemock/web/mock/graphql/web/view/controller/AbstractGraphQLViewController.java
+++ b/web/mock/graphql/src/main/java/com/castlemock/web/mock/graphql/web/view/controller/AbstractGraphQLViewController.java
@@ -24,6 +24,8 @@ import org.slf4j.Logger;
 import java.util.LinkedList;
 import java.util.List;
 
+import javax.servlet.http.HttpServletRequest;
+
 /**
  * The class operates as a shared base for all the view related to the Graph QL module
  * @author Karl Dahlgren
@@ -71,16 +73,14 @@ public abstract class AbstractGraphQLViewController extends AbstractViewControll
 
     /**
      * The method provides the functionality to create the address which is used to invoke a GraphQL service
-     * @param protocol THe protocol
-     * @param serverPort The server port
+     * @param request The HttpServletRequest instance
      * @param projectId The id of the project
      * @param applicationId The id of the application
      * @return A URL based on all the incoming parameters
      */
-    protected String getGraphQLInvokeAddress(final String protocol, int serverPort, final String projectId, final String applicationId){
+    protected String getGraphQLInvokeAddress(final HttpServletRequest request, final String projectId, final String applicationId){
         try {
-            final String hostAddress = getHostAddress();
-            return protocol + hostAddress + ":" + serverPort + getContext() + SLASH + MOCK + SLASH + GRAPHQL + SLASH + PROJECT + SLASH + projectId + SLASH + APPLICATION + SLASH + applicationId;
+            return getBaseUrlInfo(request).getBaseUrl() + SLASH + MOCK + SLASH + GRAPHQL + SLASH + PROJECT + SLASH + projectId + SLASH + APPLICATION + SLASH + applicationId;
         } catch (Exception exception) {
             LOGGER.error("Unable to generate invoke URL", exception);
             throw new IllegalStateException("Unable to generate invoke URL for " + projectId);

--- a/web/mock/graphql/src/main/java/com/castlemock/web/mock/graphql/web/view/controller/application/GraphQLApplicationController.java
+++ b/web/mock/graphql/src/main/java/com/castlemock/web/mock/graphql/web/view/controller/application/GraphQLApplicationController.java
@@ -33,7 +33,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
 
 
 /**
@@ -64,7 +64,7 @@ public class GraphQLApplicationController extends AbstractGraphQLViewController 
     public ModelAndView getApplication(@PathVariable final String projectId,
                                        @PathVariable final String applicationId,
                                         @RequestParam(value = UPLOAD, required = false) final String upload,
-                                       final ServletRequest request) {
+                                       final HttpServletRequest request) {
         final ReadGraphQLApplicationOutput output =  serviceProcessor.process(new ReadGraphQLApplicationInput(projectId, applicationId));
         final GraphQLApplication application = output.getGraphQLApplication();
 
@@ -77,9 +77,7 @@ public class GraphQLApplicationController extends AbstractGraphQLViewController 
         model.addObject(GraphQL_SUBSCRIPTION_MODIFIER_COMMAND, new GraphQLSubscriptionModifierCommand());
 
 
-        final String protocol = getProtocol(request);
-        final int port = request.getServerPort();
-        final String invokeAddress = getGraphQLInvokeAddress(protocol, port, projectId, applicationId);
+        final String invokeAddress = getGraphQLInvokeAddress(request, projectId, applicationId);
 
         application.setInvokeAddress(invokeAddress);
 

--- a/web/mock/rest/src/main/java/com/castlemock/web/mock/rest/web/view/controller/AbstractRestViewController.java
+++ b/web/mock/rest/src/main/java/com/castlemock/web/mock/rest/web/view/controller/AbstractRestViewController.java
@@ -24,6 +24,8 @@ import org.slf4j.Logger;
 import java.util.LinkedList;
 import java.util.List;
 
+import javax.servlet.http.HttpServletRequest;
+
 /**
  * The class operates as a shared base for all the view related to the REST module
  * @author Karl Dahlgren
@@ -70,17 +72,15 @@ public class AbstractRestViewController extends AbstractViewController {
 
     /**
      * The method provides the functionality to create the address which is used to invoke a REST service
-     * @param protocol THe protocol
-     * @param serverPort The server port
+     * @param request The HttpServletRequest instance
      * @param projectId The id of the project
      * @param applicationId The id of the application
      * @param resourceUri The resource uri
      * @return A URL based on all the incoming parameters
      */
-    protected String getRestInvokeAddress(final String protocol, int serverPort, final String projectId, final String applicationId, final String resourceUri){
+    protected String getRestInvokeAddress(final HttpServletRequest request , final String projectId, final String applicationId, final String resourceUri){
         try {
-            final String hostAddress = getHostAddress();
-            return protocol + hostAddress + ":" + serverPort + getContext() + SLASH + MOCK + SLASH + REST + SLASH + PROJECT + SLASH + projectId + SLASH + APPLICATION + SLASH + applicationId + resourceUri;
+            return getBaseUrlInfo(request).getBaseUrl() + SLASH + MOCK + SLASH + REST + SLASH + PROJECT + SLASH + projectId + SLASH + APPLICATION + SLASH + applicationId + resourceUri;
         } catch (Exception exception) {
             LOGGER.error("Unable to generate invoke URL", exception);
             throw new IllegalStateException("Unable to generate invoke URL for " + projectId);

--- a/web/mock/rest/src/main/java/com/castlemock/web/mock/rest/web/view/controller/method/RestMethodController.java
+++ b/web/mock/rest/src/main/java/com/castlemock/web/mock/rest/web/view/controller/method/RestMethodController.java
@@ -37,7 +37,8 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.context.i18n.LocaleContextHolder;
 
-import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -79,7 +80,7 @@ public class RestMethodController extends AbstractRestViewController {
                                     @PathVariable final String restApplicationId,
                                     @PathVariable final String restResourceId,
                                     @PathVariable final String restMethodId,
-                                    final ServletRequest request) {
+                                    final HttpServletRequest request) {
         final ReadRestResourceOutput readRestResourceOutput = serviceProcessor.process(ReadRestResourceInput.builder()
                 .restProjectId(restProjectId)
                 .restApplicationId(restApplicationId)
@@ -97,8 +98,7 @@ public class RestMethodController extends AbstractRestViewController {
                 .restMethodId(restMethodId)
                 .build());
 
-        final String protocol = getProtocol(request);
-        final String invokeAddress = getRestInvokeAddress(protocol, request.getServerPort(), restProjectId, restApplicationId, restResource.getUri());
+        final String invokeAddress = getRestInvokeAddress(request, restProjectId, restApplicationId, restResource.getUri());
         restMethod.setInvokeAddress(invokeAddress);
 
         final ModelAndView model = createPartialModelAndView(PAGE);

--- a/web/mock/rest/src/main/java/com/castlemock/web/mock/rest/web/view/controller/resource/RestResourceController.java
+++ b/web/mock/rest/src/main/java/com/castlemock/web/mock/rest/web/view/controller/resource/RestResourceController.java
@@ -36,7 +36,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -73,7 +74,7 @@ public class RestResourceController extends AbstractRestViewController {
     public ModelAndView defaultPage(@PathVariable final String restProjectId,
                                     @PathVariable final String restApplicationId,
                                     @PathVariable final String restResourceId,
-                                    final ServletRequest request) {
+                                    final HttpServletRequest request) {
         final ReadRestResourceOutput output = serviceProcessor.process(ReadRestResourceInput.builder()
                 .restProjectId(restProjectId)
                 .restApplicationId(restApplicationId)
@@ -81,8 +82,7 @@ public class RestResourceController extends AbstractRestViewController {
                 .build());
         final RestResource restResource = output.getRestResource();
 
-        final String protocol = getProtocol(request);
-        final String invokeAddress = getRestInvokeAddress(protocol, request.getServerPort(),
+        final String invokeAddress = getRestInvokeAddress(request,
                 restProjectId, restApplicationId, restResource.getUri());
         restResource.setInvokeAddress(invokeAddress);
         final ModelAndView model = createPartialModelAndView(PAGE);

--- a/web/mock/rest/src/test/java/com/castlemock/web/mock/rest/web/view/controller/resource/RestResourceControllerTest.java
+++ b/web/mock/rest/src/test/java/com/castlemock/web/mock/rest/web/view/controller/resource/RestResourceControllerTest.java
@@ -33,6 +33,8 @@ import com.castlemock.web.basis.web.AbstractController;
 import com.castlemock.web.mock.rest.config.TestApplication;
 import com.castlemock.web.mock.rest.web.view.command.method.RestMethodModifierCommand;
 import com.castlemock.web.mock.rest.web.view.controller.AbstractRestControllerTest;
+
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -62,6 +64,8 @@ import static org.mockito.Mockito.when;
 public class RestResourceControllerTest extends AbstractRestControllerTest {
 
     private static final String PAGE = "partial/mock/rest/resource/restResource.jsp";
+    private static final String HTTP = "http://";
+    private static final String LOCALHOST = "localhost";
     private static final String SLASH = "/";
     private static final String DELETE_REST_METHODS_PAGE = "partial/mock/rest/method/deleteRestMethods.jsp";
     private static final String DELETE_REST_METHODS_COMMAND = "command";
@@ -98,7 +102,9 @@ public class RestResourceControllerTest extends AbstractRestControllerTest {
                 .andExpect(MockMvcResultMatchers.model().attribute(REST_APPLICATION_ID, restApplication.getId()))
                 .andExpect(MockMvcResultMatchers.model().attribute(REST_RESOURCE, restResource));
         RestResource restResourceResponse = (RestResource) result.andReturn().getModelAndView().getModel().get(REST_RESOURCE);
-        String hostAddress = restResourceController.getHostAddress();
+
+        Assert.assertEquals(HTTP + LOCALHOST + SLASH + MOCK + SLASH + REST + SLASH + PROJECT + SLASH + restProject.getId() 
+        	+ SLASH + APPLICATION + SLASH + restApplication.getId() + restResource.getUri(), restResourceResponse.getInvokeAddress());
     }
 
     @Test

--- a/web/mock/soap/src/main/java/com/castlemock/web/mock/soap/web/view/controller/AbstractSoapViewController.java
+++ b/web/mock/soap/src/main/java/com/castlemock/web/mock/soap/web/view/controller/AbstractSoapViewController.java
@@ -24,6 +24,8 @@ import org.slf4j.Logger;
 import java.util.LinkedList;
 import java.util.List;
 
+import javax.servlet.http.HttpServletRequest;
+
 /**
  * The class operates as a shared base for all the view related to the SOAP module
  * @author Karl Dahlgren
@@ -55,16 +57,14 @@ public class AbstractSoapViewController extends AbstractViewController {
 
     /**
      * The method provides the functionality to create the address which is used to invoke a SOAP service
-     * @param protocol THe protocol
-     * @param serverPort The server port
+     * @param request The HttpServletRequest instance
      * @param projectId The id of the project
      * @param urlPath The URL path (The end of the URL, which is used to identify the SOAP service)
      * @return A URL based on all the incoming parameters
      */
-    protected String getSoapInvokeAddress(final String protocol, int serverPort, final String projectId, final String urlPath){
+    protected String getSoapInvokeAddress(final HttpServletRequest request, final String projectId, final String urlPath){
         try {
-            final String hostAddress = getHostAddress();
-            return protocol + hostAddress + ":" + serverPort + getContext() + SLASH + MOCK + SLASH + SOAP + SLASH + PROJECT + SLASH + projectId + SLASH + urlPath;
+        	return getBaseUrlInfo(request).getBaseUrl() + SLASH + MOCK + SLASH + SOAP + SLASH + PROJECT + SLASH + projectId + SLASH + urlPath;
         } catch (Exception exception) {
             LOGGER.error("Unable to generate invoke URL", exception);
             throw new IllegalStateException("Unable to generate invoke URL for " + projectId);

--- a/web/mock/soap/src/main/java/com/castlemock/web/mock/soap/web/view/controller/operation/SoapOperationController.java
+++ b/web/mock/soap/src/main/java/com/castlemock/web/mock/soap/web/view/controller/operation/SoapOperationController.java
@@ -38,7 +38,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -74,7 +75,7 @@ public class SoapOperationController extends AbstractSoapViewController {
     public ModelAndView defaultPage(@PathVariable final String soapProjectId,
                                     @PathVariable final String soapPortId,
                                     @PathVariable final String soapOperationId,
-                                    final ServletRequest request) {
+                                    final HttpServletRequest request) {
         final ReadSoapPortOutput readSoapPortOutput = serviceProcessor.process(ReadSoapPortInput.builder()
                 .projectId(soapProjectId)
                 .portId(soapPortId)
@@ -91,8 +92,7 @@ public class SoapOperationController extends AbstractSoapViewController {
                 .operationId(soapOperationId)
                 .build());
 
-        final String protocol = getProtocol(request);
-        final String invokeAddress = getSoapInvokeAddress(protocol, request.getServerPort(), soapProjectId, soapPort.getUri());
+        final String invokeAddress = getSoapInvokeAddress(request, soapProjectId, soapPort.getUri());
         soapOperation.setInvokeAddress(invokeAddress);
 
         final ModelAndView model = createPartialModelAndView(PAGE);

--- a/web/mock/soap/src/main/java/com/castlemock/web/mock/soap/web/view/controller/port/SoapPortController.java
+++ b/web/mock/soap/src/main/java/com/castlemock/web/mock/soap/web/view/controller/port/SoapPortController.java
@@ -35,7 +35,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -68,14 +69,13 @@ public class SoapPortController extends AbstractSoapViewController {
     @RequestMapping(value = "/{soapProjectId}/port/{soapPortId}", method = RequestMethod.GET)
     public ModelAndView getSoapPort(@PathVariable final String soapProjectId,
                                     @PathVariable final String soapPortId,
-                                    final ServletRequest request) {
+                                    final HttpServletRequest request) {
         final ReadSoapPortOutput readSoapPortOutput = serviceProcessor.process(ReadSoapPortInput.builder()
                 .projectId(soapProjectId)
                 .portId(soapPortId)
                 .build());
         final SoapPort soapPort = readSoapPortOutput.getPort();
-        final String protocol = getProtocol(request);
-        final String invokeAddress = getSoapInvokeAddress(protocol, request.getServerPort(), soapProjectId, soapPort.getUri());
+        final String invokeAddress = getSoapInvokeAddress(request, soapProjectId, soapPort.getUri());
 
         soapPort.setInvokeAddress(invokeAddress);
         final ModelAndView model = createPartialModelAndView(PAGE);

--- a/web/mock/soap/src/test/java/com/castlemock/web/mock/soap/web/view/controller/operation/SoapOperationControllerTest.java
+++ b/web/mock/soap/src/test/java/com/castlemock/web/mock/soap/web/view/controller/operation/SoapOperationControllerTest.java
@@ -74,6 +74,7 @@ public class SoapOperationControllerTest extends AbstractSoapControllerTest {
     private static final String DELETE_MOCK_RESPONSES_PAGE = "partial/mock/soap/mockresponse/deleteSoapMockResponses.jsp";
     private static final String SLASH = "/";
     private static final String HTTP = "http://";
+    private static final String LOCALHOST = "localhost";
     private static final String MOCK = "mock";
     private static final String COLON = ":";
     private static final String SOAP = "soap";
@@ -115,8 +116,7 @@ public class SoapOperationControllerTest extends AbstractSoapControllerTest {
                 .andExpect(MockMvcResultMatchers.model().attribute(SOAP_PORT_ID, soapPort.getId()))
                 .andExpect(MockMvcResultMatchers.model().attribute(SOAP_OPERATION, soapOperation));
         SoapOperation SoapOperationResponse = (SoapOperation) result.andReturn().getModelAndView().getModel().get(SOAP_OPERATION);
-        String hostAddress = serviceController.getHostAddress();
-        Assert.assertEquals(HTTP + hostAddress + COLON + DEFAULT_PORT + CONTEXT + SLASH + MOCK + SLASH + SOAP + SLASH + PROJECT + SLASH + soapProject.getId() + SLASH + soapPort.getUri(), soapOperation.getInvokeAddress());
+        Assert.assertEquals(HTTP + LOCALHOST + SLASH + MOCK + SLASH + SOAP + SLASH + PROJECT + SLASH + soapProject.getId() + SLASH + soapPort.getUri(), soapOperation.getInvokeAddress());
     }
 
 


### PR DESCRIPTION
This pull request fixes https://github.com/castlemock/castlemock/issues/225 and fixes https://github.com/castlemock/castlemock/issues/183

## Implementation details

Two new classes have been created: `BaseUrlInfo` and` BaseUrlInfo.Builder`.

The following logic is used now:
* `serverName`: if` preferedServerName` is non-null and non-empty, it will be used as the server name. Otherwise, the server name will be obtained from `request.getServerName()`
* `serverPort` and `contextPath` was obtained from `request`.
* `BaseUrlInfo.getBaseUrl()` and `BaseUrlInfo.getServerUrl()` don't append 80 or 443 ports to the URL.
* `protocol` is obtained from `request.getHeader("X-Forwarded-Proto")` or from `request.getScheme()` instead of checking `request.isSecure()`.

The method `public BaseUrlInfo getBaseUrlInfo(final HttpServletRequest request)` was created on class `AbstractController`, and it passes the value of `server.endpoint.address` environment setting as the `preferedServerName`, to keep backward compatibility.

The method `AbstractController.getHostAddress()` has been removed, because it is no longer used.                                                 

