### PR TITLE
Upgrade junit from 4.12 to junit-vintage-engine 5.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
         <java.release>8</java.release>
         <java.version>1.8</java.version>
         <jaxb.version>2.3.1</jaxb.version>
-        <junit.version>4.12</junit.version>
         <dozer.version>5.5.1</dozer.version>
         <antlr.version>4.8-1</antlr.version>
         <log4j.version>2.13.3</log4j.version>
@@ -54,12 +53,11 @@
         <jaxb.runtime.version>2.3.2</jaxb.runtime.version>
         <swagger.core.version>1.6.0</swagger.core.version>
         <commons.codec.version>1.14</commons.codec.version>
-        <junit.jupiter.version>5.6.0</junit.jupiter.version>
+        <junit.jupiter.version>5.7.0</junit.jupiter.version>
         <tomcat.embedd.version>9.0.37</tomcat.embedd.version>
         <json.schema.validator>2.2.13</json.schema.validator>
         <xmlschema.core.version>2.2.5</xmlschema.core.version>
         <maven.compiler.version>3.8.1</maven.compiler.version>
-        <junit.platform.version>1.6.2</junit.platform.version>
         <swagger.parser.version>2.0.21</swagger.parser.version>
         <spring.boot.version>2.3.3.RELEASE</spring.boot.version>
         <maven.war.plugin.version>3.2.3</maven.war.plugin.version>
@@ -636,6 +634,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+                <version>${junit.jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>de.flapdoodle.embed</groupId>
                 <artifactId>de.flapdoodle.embed.mongo</artifactId>
                 <version>${flapdoodle.mongo.version}</version>
@@ -645,18 +649,6 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-all</artifactId>
                 <version>${mockito.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.platform</groupId>
-                <artifactId>junit-platform-commons</artifactId>
-                <version>${junit.platform.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -709,8 +701,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/web/mock/soap/src/test/java/com/castlemock/web/mock/soap/utility/config/AddressLocationConfigurerTest.java
+++ b/web/mock/soap/src/test/java/com/castlemock/web/mock/soap/utility/config/AddressLocationConfigurerTest.java
@@ -1,7 +1,7 @@
 package com.castlemock.web.mock.soap.utility.config;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class AddressLocationConfigurerTest {
 	
@@ -31,13 +31,13 @@ public class AddressLocationConfigurerTest {
 	@Test
 	public void testWsdlWithAddressLocation() {
 		String wsdlModified = new AddressLocationConfigurer().configureAddressLocation(ORIGINAL_WSDL_WITH_ADDRESS_LOCATION, "http://localhost:8080/other-path");
-		Assert.assertEquals(MODIFIED_WSDL_WITH_ADDRESS_LOCATION, wsdlModified);
+		Assertions.assertEquals(MODIFIED_WSDL_WITH_ADDRESS_LOCATION, wsdlModified);
 	}
 	
 	@Test
 	public void testWsdlWithoutAddressLocation() {
 		String wsdlResult = new AddressLocationConfigurer().configureAddressLocation(WSDL_WITHOU_ADDRESS_LOCATION, "http://localhost:8080/other-path");
-		Assert.assertEquals(WSDL_WITHOU_ADDRESS_LOCATION, wsdlResult);
+		Assertions.assertEquals(WSDL_WITHOU_ADDRESS_LOCATION, wsdlResult);
 	}
 
 }


### PR DESCRIPTION
This pull request upgrade `junit` from `4.12` to `junit-vintage-engine 5.7.0`.

[JUnit Vintage](https://junit.org/junit5/docs/5.7.0/user-guide/#overview-what-is-junit-5) provides a TestEngine for running JUnit 3 and JUnit 4 based tests on the  JUnit Platform.

This upgrade allows the use of both the JUnit 5 API and the Junit 4 API.

Example with JUnit 4 API:
```java
import org.junit.Assert;
import org.junit.Test;

public class MyJUnit4Test {
  @Test
  public void testWithJUnit4Api() {
    Assert.assertEquals("a", "b");
  }
}
```

Example with JUnit 5 API:
```java
import org.junit.jupiter.api.Assertions;
import org.junit.jupiter.api.Test;

public class MyJUnit5Test {
  @Test
  public void testWithJUnit5Api() {
    Assertions.assertEquals("a", "b");
  }
}
```