### PR TITLE
Increase performance when using expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -282,3 +282,10 @@ typings/
 # End of https://www.gitignore.io/api/node
 
 node/
+
+# Eclipse IDE
+.project
+/.apt_generated/
+/.apt_generated_tests/
+.classpath
+.factorypath

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "files.exclude": {
+        "**/.classpath": true,
+        "**/.project": true,
+        "**/.settings": true,
+        "**/.factorypath": true
+    }
+}

--- a/model/model-core/src/main/java/com/castlemock/model/core/http/HttpParameter.java
+++ b/model/model-core/src/main/java/com/castlemock/model/core/http/HttpParameter.java
@@ -28,6 +28,15 @@ public class HttpParameter {
 
     private String name;
     private String value;
+    
+    public HttpParameter() {
+        
+    }
+    
+    public HttpParameter(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
 
     @XmlElement
     public String getName() {

--- a/model/model-core/src/main/java/com/castlemock/model/core/utility/parser/ExternalInputBuilder.java
+++ b/model/model-core/src/main/java/com/castlemock/model/core/utility/parser/ExternalInputBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Karl Dahlgren
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.castlemock.model.core.utility.parser;
 
 import java.util.List;

--- a/model/model-core/src/main/java/com/castlemock/model/core/utility/parser/ExternalInputBuilder.java
+++ b/model/model-core/src/main/java/com/castlemock/model/core/utility/parser/ExternalInputBuilder.java
@@ -1,0 +1,81 @@
+package com.castlemock.model.core.utility.parser;
+
+import java.util.List;
+import java.util.Map;
+
+import com.castlemock.model.core.http.HttpParameter;
+import com.castlemock.model.core.utility.parser.expression.BodyXPathExpression;
+import com.castlemock.model.core.utility.parser.expression.PathParameterExpression;
+import com.castlemock.model.core.utility.parser.expression.QueryStringExpression;
+import com.castlemock.model.core.utility.parser.expression.UrlHostExpression;
+import com.castlemock.model.core.utility.parser.expression.argument.ExpressionArgument;
+import com.castlemock.model.core.utility.parser.expression.argument.ExpressionArgumentMap;
+import com.castlemock.model.core.utility.parser.expression.argument.ExpressionArgumentString;
+import com.google.common.collect.ImmutableMap;
+
+public class ExternalInputBuilder {
+	private String requestBody;
+	private String requestUrl;
+	private Map<String, String> pathParameters;
+	private List<HttpParameter> queryStringParameters;
+	
+	public ExternalInputBuilder requestBody(final String requestBody) {
+		this.requestBody = requestBody;
+		return this;
+	}
+	
+	public ExternalInputBuilder requestUrl(final String requestUrl) {
+		this.requestUrl = requestUrl;
+		return this;
+	}
+	
+	public ExternalInputBuilder pathParameters(final Map<String, String> pathParameters) {
+		this.pathParameters= pathParameters;
+		return this;
+	}
+	
+	public ExternalInputBuilder queryStringParameters(final List<HttpParameter> queryStringParameters) {
+		this.queryStringParameters = queryStringParameters;
+		return this;
+	}
+	
+	public Map<String, ExpressionArgument<?>> build() {
+		ImmutableMap.Builder<String, ExpressionArgument<?>> immutableMapBuilder = ImmutableMap.builder();
+		if (this.requestBody != null) {
+			final ExpressionArgument<?> bodyArgument = new ExpressionArgumentString(this.requestBody);
+			immutableMapBuilder.put(BodyXPathExpression.BODY_ARGUMENT, bodyArgument);
+		}
+		if (this.requestUrl != null) {
+			final ExpressionArgument<?> urlArgument = new ExpressionArgumentString(this.requestUrl);
+			immutableMapBuilder.put(UrlHostExpression.URL_ARGUMENT, urlArgument);
+		}
+		if (this.pathParameters != null) {
+			immutableMapBuilder.put(PathParameterExpression.PATH_PARAMETERS, buildPathParametersArgument());
+		}
+		if (this.queryStringParameters != null) {
+			immutableMapBuilder.put(QueryStringExpression.QUERY_STRINGS, buildQueryStringArgument());
+		}
+		
+		final Map<String, ExpressionArgument<?>> externalInput = immutableMapBuilder.build();
+		return externalInput;
+	}
+	
+	private ExpressionArgumentMap buildPathParametersArgument() {
+		final ExpressionArgumentMap pathParametersArgument = new ExpressionArgumentMap();
+        this.pathParameters.forEach((key, value) -> {
+            ExpressionArgument<?> pathParameterArgument = new ExpressionArgumentString(value);
+            pathParametersArgument.addArgument(key, pathParameterArgument);
+        });
+        return pathParametersArgument;
+	}
+	
+	private final ExpressionArgumentMap buildQueryStringArgument() {
+		final ExpressionArgumentMap queryStringArgument = new ExpressionArgumentMap();
+        this.queryStringParameters.forEach(parameter -> {
+            ExpressionArgument<?> pathParameterArgument = new ExpressionArgumentString(parameter.getValue());
+            queryStringArgument.addArgument(parameter.getName(), pathParameterArgument);
+        });
+        return queryStringArgument;
+	}
+
+}

--- a/model/model-core/src/test/java/com/castlemock/model/core/utility/parser/ExternalInputBuilderTest.java
+++ b/model/model-core/src/test/java/com/castlemock/model/core/utility/parser/ExternalInputBuilderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Karl Dahlgren
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.castlemock.model.core.utility.parser;
 
 import java.util.ArrayList;

--- a/model/model-core/src/test/java/com/castlemock/model/core/utility/parser/ExternalInputBuilderTest.java
+++ b/model/model-core/src/test/java/com/castlemock/model/core/utility/parser/ExternalInputBuilderTest.java
@@ -1,0 +1,79 @@
+package com.castlemock.model.core.utility.parser;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.castlemock.model.core.http.HttpParameter;
+import com.castlemock.model.core.utility.parser.expression.BodyXPathExpression;
+import com.castlemock.model.core.utility.parser.expression.PathParameterExpression;
+import com.castlemock.model.core.utility.parser.expression.QueryStringExpression;
+import com.castlemock.model.core.utility.parser.expression.UrlHostExpression;
+import com.castlemock.model.core.utility.parser.expression.argument.ExpressionArgument;
+import com.castlemock.model.core.utility.parser.expression.argument.ExpressionArgumentString;
+
+class ExternalInputBuilderTest {
+	private static Map<String, String> pathParameters;
+	private static List<HttpParameter> queryStringParameters;
+	
+	@BeforeAll
+	static void initAll() {
+		pathParameters = new HashMap<>();
+    	pathParameters.put("param1", "X");
+    	pathParameters.put("param2", "Y");
+    	pathParameters.put("param3", "Z");
+
+    	queryStringParameters = new ArrayList<>();
+    	queryStringParameters.add(new HttpParameter("queryParam1", "Apple"));
+    	queryStringParameters.add(new HttpParameter("queryParam2", "Orange"));
+    	queryStringParameters.add(new HttpParameter("queryParam3", "Banana"));
+    	queryStringParameters.add(new HttpParameter("queryParam4", "Papaya"));
+	}
+	
+	@Test
+	void testPathParameters() {
+    	final Map<String, ExpressionArgument<?>> externalInput = new ExternalInputBuilder().pathParameters(pathParameters).build();
+    	
+    	Assertions.assertTrue(externalInput.containsKey(PathParameterExpression.PATH_PARAMETERS));
+    	@SuppressWarnings("unchecked")
+        Map<String, ExpressionArgumentString> returnedPathParameter = (Map<String, ExpressionArgumentString>) externalInput.get(PathParameterExpression.PATH_PARAMETERS).getValue();
+    	Assertions.assertEquals("X", returnedPathParameter.get("param1").getValue());
+    	Assertions.assertEquals("Y", returnedPathParameter.get("param2").getValue());
+    	Assertions.assertEquals("Z", returnedPathParameter.get("param3").getValue());
+	}
+	
+	@Test
+	void testQueryStringParameters() {
+    	final Map<String, ExpressionArgument<?>> externalInput = new ExternalInputBuilder().queryStringParameters(queryStringParameters).build();
+    	
+    	Assertions.assertTrue(externalInput.containsKey(QueryStringExpression.QUERY_STRINGS));
+    	@SuppressWarnings("unchecked")
+    	Map<String, ExpressionArgumentString> returnedQueryString = (Map<String, ExpressionArgumentString>) externalInput.get(QueryStringExpression.QUERY_STRINGS).getValue();
+    	Assertions.assertEquals("Apple", returnedQueryString.get("queryParam1").getValue());
+    	Assertions.assertEquals("Orange", returnedQueryString.get("queryParam2").getValue());
+    	Assertions.assertEquals("Banana", returnedQueryString.get("queryParam3").getValue());
+    	Assertions.assertEquals("Papaya", returnedQueryString.get("queryParam4").getValue());
+	}
+	
+	@Test
+	void testRequestUrl() {
+		final String requestUrl = "http://localhost:8080/castlemock";
+		final Map<String, ExpressionArgument<?>> externalInput = new ExternalInputBuilder().requestUrl(requestUrl).build();
+		String returnedRequestUrl = (String) externalInput.get(UrlHostExpression.URL_ARGUMENT).getValue();
+		Assertions.assertEquals("http://localhost:8080/castlemock", returnedRequestUrl);
+	}
+	
+	@Test
+	void testRequestBody() {
+		final String requestBody = "Body content";
+		final Map<String, ExpressionArgument<?>> externalInput = new ExternalInputBuilder().requestBody(requestBody).build();
+		String returnedRequestBody = (String) externalInput.get(BodyXPathExpression.BODY_ARGUMENT).getValue();
+		Assertions.assertEquals("Body content", returnedRequestBody);
+	}
+
+}

--- a/model/model-core/src/test/java/com/castlemock/model/core/utility/parser/TextParseMockConfig.java
+++ b/model/model-core/src/test/java/com/castlemock/model/core/utility/parser/TextParseMockConfig.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Karl Dahlgren
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.castlemock.model.core.utility.parser;
 
 import java.util.HashMap;

--- a/model/model-core/src/test/java/com/castlemock/model/core/utility/parser/TextParseMockConfig.java
+++ b/model/model-core/src/test/java/com/castlemock/model/core/utility/parser/TextParseMockConfig.java
@@ -1,0 +1,77 @@
+package com.castlemock.model.core.utility.parser;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mockito.Mockito;
+
+import com.castlemock.model.core.utility.parser.expression.BodyJsonPathExpression;
+import com.castlemock.model.core.utility.parser.expression.BodyXPathExpression;
+import com.castlemock.model.core.utility.parser.expression.Expression;
+import com.castlemock.model.core.utility.parser.expression.ExpressionInput;
+import com.castlemock.model.core.utility.parser.expression.FakerExpression;
+import com.castlemock.model.core.utility.parser.expression.PathParameterExpression;
+import com.castlemock.model.core.utility.parser.expression.QueryStringExpression;
+import com.castlemock.model.core.utility.parser.expression.RandomBooleanExpression;
+import com.castlemock.model.core.utility.parser.expression.RandomDateExpression;
+import com.castlemock.model.core.utility.parser.expression.RandomDateTimeExpression;
+import com.castlemock.model.core.utility.parser.expression.RandomDoubleExpression;
+import com.castlemock.model.core.utility.parser.expression.RandomEmailExpression;
+import com.castlemock.model.core.utility.parser.expression.RandomEnumExpression;
+import com.castlemock.model.core.utility.parser.expression.RandomFloatExpression;
+import com.castlemock.model.core.utility.parser.expression.RandomIntegerExpression;
+import com.castlemock.model.core.utility.parser.expression.RandomLongExpression;
+import com.castlemock.model.core.utility.parser.expression.RandomPasswordExpression;
+import com.castlemock.model.core.utility.parser.expression.RandomStringExpression;
+import com.castlemock.model.core.utility.parser.expression.RandomUUIDExpression;
+import com.castlemock.model.core.utility.parser.expression.UrlHostExpression;
+
+class TextParseMockConfig {
+	
+	public TextParseMockConfig() {
+		this.mockedExpressions = configureMockedExpressions();
+	}
+	
+	private Map<String,Expression> mockedExpressions;
+	
+	public Map<String,Expression> getMockedExpressions() {
+		return this.mockedExpressions;
+	}
+	
+	private Map<String,Expression> configureMockedExpressions() {
+    	final Map<String,Expression> expressions = new HashMap<>();
+    	registerMockExpression(expressions, RandomIntegerExpression.IDENTIFIER, "1", "2", "3");
+    	registerMockExpression(expressions, RandomDoubleExpression.IDENTIFIER, "9.07231552E8", "1.971414777E9");
+    	registerMockExpression(expressions, RandomLongExpression.IDENTIFIER, "8345852683487585923","4396544029006714971");
+    	registerMockExpression(expressions, RandomFloatExpression.IDENTIFIER, "0.77921385", "0.52562904");
+    	registerMockExpression(expressions, RandomBooleanExpression.IDENTIFIER, "false", "true");
+    	registerMockExpression(expressions, RandomDateExpression.IDENTIFIER, "2019-01-07", "2020-10-15");
+    	registerMockExpression(expressions, RandomStringExpression.IDENTIFIER, "XfDbd6sk90hxH0L", "s80ho4iJTlda");
+    	registerMockExpression(expressions, RandomUUIDExpression.IDENTIFIER, "bf60cb57-cfd8-43bb-83f7-62b1584c29d7", "af88f1d8-c8f6-4407-903c-18ffe6ac06c5");
+    	registerMockExpression(expressions, RandomEmailExpression.IDENTIFIER, "Cng73JRbJT@RliQvDuVVN8.com", "C0GlhHZ4vL@6ZNPRPmX.com");
+    	registerMockExpression(expressions, RandomPasswordExpression.IDENTIFIER, "j5HC7UGSVp", "p70ggj9409ia");
+    	registerMockExpression(expressions, RandomDateTimeExpression.IDENTIFIER, "2008-02-09T21:42:10", "2048-09-26T06:39:22");
+    	registerMockExpression(expressions, RandomEnumExpression.IDENTIFIER, "available", "Z");
+    	registerMockExpression(expressions, FakerExpression.IDENTIFIER, "Peter", "Paul"); 
+    	expressions.put(PathParameterExpression.IDENTIFIER, new PathParameterExpression());
+    	expressions.put(QueryStringExpression.IDENTIFIER, new QueryStringExpression());
+    	expressions.put(BodyJsonPathExpression.IDENTIFIER, new BodyJsonPathExpression());
+    	expressions.put(UrlHostExpression.IDENTIFIER, new UrlHostExpression());
+    	expressions.put(BodyXPathExpression.IDENTIFIER, new BodyXPathExpression());
+    	
+    	return expressions;
+	}
+	
+	private void registerMockExpression(final Map<String,Expression> expressions, String name, String value, String... values) {
+		Expression mockExpression = mockExpression(name, value, values);
+		expressions.put(name, mockExpression);		
+	}
+	
+	private Expression mockExpression(String name, String value, String... values) {
+		Expression mockExpression = Mockito.mock(Expression.class);
+		Mockito.when(mockExpression.match(name)).thenReturn(true);
+		Mockito.when(mockExpression.transform(Mockito.any(ExpressionInput.class))).thenReturn(value, values);
+		return mockExpression;
+	}	
+
+}

--- a/model/model-core/src/test/java/com/castlemock/model/core/utility/parser/TextParserTest.java
+++ b/model/model-core/src/test/java/com/castlemock/model/core/utility/parser/TextParserTest.java
@@ -16,8 +16,20 @@
 
 package com.castlemock.model.core.utility.parser;
 
-import org.junit.Assert;
-import org.junit.Test;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.castlemock.model.core.http.HttpParameter;
+import com.google.common.io.Resources;
 
 
 /**
@@ -25,52 +37,227 @@ import org.junit.Test;
  * @author Karl Dahlgren
  */
 public class TextParserTest {
+    private TextParser textParser = new TextParser();
+    private TextParser textParserMockedExpressions;
+
+    
+    @BeforeEach
+    void init() {
+        this.textParserMockedExpressions = new TextParser(new TextParseMockConfig().getMockedExpressions());
+    }
 
     @Test
     public void testParseNull(){
         String input = null;
-        String output = TextParser.parse(input);
-        Assert.assertNull(output);
+        String output = this.textParser.parse(input);
+        Assertions.assertNull(output);
     }
 
     @Test
     public void testParseRandomInteger(){
         String input = "Hello this is a ${RANDOM_INTEGER}.";
-        String output = TextParser.parse(input);
-        Assert.assertNotEquals(input, output);
-        Assert.assertTrue(output.matches("Hello this is a (.*?)."));
+        String output = textParser.parse(input);
+        Assertions.assertNotEquals(input, output);
+        Assertions.assertTrue(output.matches("Hello this is a (.*?)."));
+        
+        input = "a: ${RANDOM_INTEGER}, b: ${RANDOM_INTEGER()}.";
+        output = textParserMockedExpressions.parse(input);
+        Assertions.assertEquals("a: 1, b: 2.", output);
     }
-
+    
     @Test
     public void testParseRandomDouble(){
         String input = "Hello this is a ${RANDOM_DOUBLE}.";
-        String output = TextParser.parse(input);
-        Assert.assertNotEquals(input, output);
-        Assert.assertTrue(output.matches("Hello this is a (.*?)."));
+        String output = textParser.parse(input);
+        Assertions.assertNotEquals(input, output);
+        Assertions.assertTrue(output.matches("Hello this is a (.*?)."));
+        
+        input = "a: ${RANDOM_DOUBLE}, b: ${RANDOM_DOUBLE}.";
+        output = textParserMockedExpressions.parse(input);
+        Assertions.assertEquals("a: 9.07231552E8, b: 1.971414777E9.", output);
     }
 
     @Test
     public void testParseRandomLong(){
         String input = "Hello this is a ${RANDOM_LONG}.";
-        String output = TextParser.parse(input);
-        Assert.assertNotEquals(input, output);
-        Assert.assertTrue(output.matches("Hello this is a (.*?)."));
+        String output = textParser.parse(input);
+        Assertions.assertNotEquals(input, output);
+        Assertions.assertTrue(output.matches("Hello this is a (.*?)."));
+        
+        input = "a: ${RANDOM_LONG}, b: ${RANDOM_LONG}.";
+        output = textParserMockedExpressions.parse(input);
+        Assertions.assertEquals("a: 8345852683487585923, b: 4396544029006714971.", output);
     }
 
     @Test
     public void testParseRandomFloat(){
         String input = "Hello this is a ${RANDOM_FLOAT}.";
-        String output = TextParser.parse(input);
-        Assert.assertNotEquals(input, output);
-        Assert.assertTrue(output.matches("Hello this is a (.*?)."));
+        String output = this.textParser.parse(input);
+        Assertions.assertNotEquals(input, output);
+        Assertions.assertTrue(output.matches("Hello this is a (.*?)."));
+        
+        input = "a: ${RANDOM_FLOAT}, b: ${RANDOM_FLOAT}.";
+        output = textParserMockedExpressions.parse(input);
+        Assertions.assertEquals("a: 0.77921385, b: 0.52562904.", output);
+    }
+    
+    @Test
+    public void testParseRandomBoolean(){
+        String input = "a: ${RANDOM_BOOLEAN}, b: ${RANDOM_BOOLEAN}.";
+        String output = textParserMockedExpressions.parse(input);
+        Assertions.assertEquals("a: false, b: true.", output);
+    }
+    
+    @Test
+    public void testParseRandomDate(){
+        String input = "a: ${RANDOM_DATE}, b: ${RANDOM_DATE}.";
+        String output = textParserMockedExpressions.parse(input);
+        Assertions.assertEquals("a: 2019-01-07, b: 2020-10-15.", output);
+    }
+    
+    @Test
+    public void testParseRandomString(){
+        String input = "a: ${RANDOM_STRING}, b: ${RANDOM_STRING}.";
+        String output = textParserMockedExpressions.parse(input);
+        Assertions.assertEquals("a: XfDbd6sk90hxH0L, b: s80ho4iJTlda.", output);
+    }
+    
+    @Test
+    public void testParseRandomUUID(){
+        String input = "a: ${RANDOM_UUID}, b: ${RANDOM_UUID}.";
+        String output = textParserMockedExpressions.parse(input);
+        Assertions.assertEquals("a: bf60cb57-cfd8-43bb-83f7-62b1584c29d7, b: af88f1d8-c8f6-4407-903c-18ffe6ac06c5.", output);
+    }
+    
+    @Test
+    public void testParseRandomEmail(){
+        String input = "a: ${RANDOM_EMAIL}, b: ${RANDOM_EMAIL}.";
+        String output = textParserMockedExpressions.parse(input);
+        Assertions.assertEquals("a: Cng73JRbJT@RliQvDuVVN8.com, b: C0GlhHZ4vL@6ZNPRPmX.com.", output);
+    }
+    
+    @Test
+    public void testParseRandomPassword(){
+        String input = "a: ${RANDOM_PASSWORD}, b: ${RANDOM_PASSWORD}.";
+        String output = textParserMockedExpressions.parse(input);
+        Assertions.assertEquals("a: j5HC7UGSVp, b: p70ggj9409ia.", output);
+    }
+    
+    @Test
+    public void testParseRandomDateTime(){
+        String input = "a: ${RANDOM_DATE_TIME}, b: ${RANDOM_DATE_TIME}.";
+        String output = textParserMockedExpressions.parse(input);
+        Assertions.assertEquals("a: 2008-02-09T21:42:10, b: 2048-09-26T06:39:22.", output);
+    }
+    
+    @Test
+    public void testParseRandomEnum(){
+        String input = "a: ${RANDOM_ENUM(values=[\"available\",\"pending\",\"sold\"])}, b: ${RANDOM_ENUM(values=[\"X\",\"Y\",\"Z\"])}.";
+        String output = textParserMockedExpressions.parse(input);
+        Assertions.assertEquals("a: available, b: Z.", output);
+    }
+    
+    @Test
+    public void testParsePathParameter() throws IOException{
+        final Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put("param1", "X");
+        pathParameters.put("param2", "Y");
+        pathParameters.put("param3", "Z");
+        
+        String input = "a: ${PATH_PARAMETER(parameter=\"param1\")}, b: ${PATH_PARAMETER(parameter=\"param2\")}.";
+        String output = textParser.parse(input, new ExternalInputBuilder().pathParameters(pathParameters).build());
+        Assertions.assertEquals("a: X, b: Y.", output);
+    }
+    
+    @Test
+    public void testParseQueryString() throws IOException{
+        final List<HttpParameter> queryStringParameters = new ArrayList<>();
+        queryStringParameters.add(new HttpParameter("queryParam1", "Apple"));
+        queryStringParameters.add(new HttpParameter("queryParam2", "Orange"));
+        queryStringParameters.add(new HttpParameter("queryParam3", "Banana"));
+        queryStringParameters.add(new HttpParameter("queryParam4", "Papaya"));
+        
+        String input = "a: ${QUERY_STRING(query=\"queryParam1\")}, b: ${QUERY_STRING(query=\"queryParam2\")}.";
+        String output = textParser.parse(input, new ExternalInputBuilder().queryStringParameters(queryStringParameters).build());
+        Assertions.assertEquals("a: Apple, b: Orange.", output);
+    }
+        
+    @Test
+    public void testParseBodyJsonPath() throws IOException{
+        URL url = Resources.getResource("store-book.json");
+        final String requestBodyJson = Resources.toString(url, StandardCharsets.UTF_8);
+        
+        String input = "a: ${BODY_JSON_PATH(expression=\"$.store.book[0].title\")}, b: ${BODY_JSON_PATH(expression=\"$.store.book[1].title\")}.";
+        String output = textParser.parse(input, new ExternalInputBuilder().requestBody(requestBodyJson).build());
+        Assertions.assertEquals("a: Moby Dick, b: The Lord of the Rings.", output);
+    }
+    
+    @Test
+    public void testParseUrlHost() throws IOException{
+        String input = "a: ${URL_HOST()}, b: ${URL_HOST()}.";
+        String output = textParser.parse(input, new ExternalInputBuilder().requestUrl("http://localhost:8080/castlemock").build());
+        Assertions.assertEquals("a: localhost, b: localhost.", output);
+    }
+    
+    @Test
+    public void testParseBodyXPath() throws IOException{
+        final String requestBodyXml = "" +
+                "<user>\n" + 
+                "   <id>1</id>\n" + 
+                "   <name>Peter</name>\n" + 
+                "</user>\n";
+        
+        String input = "a: ${BODY_XPATH(expression=\"//user/id/text()\")}, b: ${BODY_XPATH(expression=\"//user/name/text()\")}.";
+        String output = textParser.parse(input, new ExternalInputBuilder().requestBody(requestBodyXml).build());
+        Assertions.assertEquals("a: 1, b: Peter.", output);
     }
     
     @Test
     public void testParseFaker(){
         String input = "Hello this is a ${FAKER(api=\"name().fullName()\")}.";
-        String output = TextParser.parse(input);
-        Assert.assertNotEquals(input, output);
-        Assert.assertTrue(output.matches("Hello this is a (.*?)."));
+        String output = textParser.parse(input);
+        Assertions.assertNotEquals(input, output);
+        Assertions.assertTrue(output.matches("Hello this is a (.*?)."));
+        
+        input = "a: ${FAKER(api=\"name().fullName()\")}, b: ${FAKER(api=\"name().fullName()\")}.";
+        output = textParserMockedExpressions.parse(input);
+        Assertions.assertEquals("a: Peter, b: Paul.", output);
     }
+    
+    @Test
+    public void testParseMultipleExpressions() {
+        String input = "a: ${RANDOM_INTEGER}, b: ${RANDOM_INTEGER()}, c: ${RANDOM_DATE()},"
+                + " d: ${RANDOM_INTEGER(min=0,max=100)}, e: ${RANDOM_DATE()}, f: ${X}.${}";
+        
+        String output = textParserMockedExpressions.parse(input);
+        Assertions.assertEquals("a: 1, b: 2, c: 2019-01-07, d: 3, e: 2020-10-15, f: ${X}.${}", output);
+    }
+    
+    
+    @Test
+    public void testParseBigResponse() {
+        final int RECORDS = 1;
+        final StringBuilder inputBuilder = new StringBuilder();
+        inputBuilder.append("<users>\n");       
+        for (int i = 0; i < RECORDS; i++) {
+            inputBuilder.append("   <user>\n");
+            inputBuilder.append("      <sequence>").append(i + 1).append("</sequence>\n");
+            inputBuilder.append("      <id>${RANDOM_LONG()}</id>\n");
+            inputBuilder.append("      <name>${RANDOM_STRING()}</name>\n");
+            inputBuilder.append(
+                    "      <email>${RANDOM_EMAIL(domain=\"castlemock\",min=5,max=10,topDomain=\"com\")}</email>\n");
+            inputBuilder.append("      <status>${RANDOM_ENUM(values=[\"active\",\"inactive\",\"locked\"])}</status>\n");
+            inputBuilder.append("   </user>\n");
+        }
+        inputBuilder.append("</users>\n");
 
+        final String input = inputBuilder.toString();
+
+        long startedAt = System.currentTimeMillis();
+        String output = textParser.parse(input);
+        
+        Assertions.assertNotEquals(input, output);
+        System.out.println("testParseBigResponse runned in " + (System.currentTimeMillis() - startedAt) + " ms");
+    }
+    
 }

--- a/model/model-core/src/test/resources/log4j.properties
+++ b/model/model-core/src/test/resources/log4j.properties
@@ -1,0 +1,9 @@
+log4j.rootLogger=WARN,stdout
+log4j.logger.com.castlemock=WARN
+log4j.logger.org.springframework=WARN
+log4j.logger.org.dozer=WARN
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/model/model-core/src/test/resources/store-book.json
+++ b/model/model-core/src/test/resources/store-book.json
@@ -1,0 +1,20 @@
+{
+    "store": {
+        "book": [
+        {
+            "category": "fiction",
+            "author": "Herman Melville",
+            "title": "Moby Dick",
+            "isbn": "0-553-21311-3",
+            "price": 8.99
+        },
+        {
+            "category": "fiction",
+            "author": "J.R.R. Tolkien",
+            "title": "The Lord of the Rings",
+            "isbn": "0-395-19395-8",
+            "price": 22.99
+        }
+        ]
+    }
+}

--- a/web/web-mock/web-mock-soap/src/main/java/com/castlemock/web/mock/soap/controller/mock/AbstractSoapServiceController.java
+++ b/web/web-mock/web-mock-soap/src/main/java/com/castlemock/web/mock/soap/controller/mock/AbstractSoapServiceController.java
@@ -21,11 +21,9 @@ import com.castlemock.model.core.http.ContentEncoding;
 import com.castlemock.model.core.http.HttpHeader;
 import com.castlemock.model.core.http.HttpMethod;
 import com.castlemock.model.core.utility.XPathUtility;
+import com.castlemock.model.core.utility.parser.ExternalInputBuilder;
 import com.castlemock.model.core.utility.parser.TextParser;
-import com.castlemock.model.core.utility.parser.expression.BodyXPathExpression;
-import com.castlemock.model.core.utility.parser.expression.UrlHostExpression;
 import com.castlemock.model.core.utility.parser.expression.argument.ExpressionArgument;
-import com.castlemock.model.core.utility.parser.expression.argument.ExpressionArgumentString;
 import com.castlemock.model.mock.soap.domain.SoapEvent;
 import com.castlemock.model.mock.soap.domain.SoapRequest;
 import com.castlemock.model.mock.soap.domain.SoapResponse;
@@ -59,7 +57,6 @@ import com.castlemock.web.mock.soap.utility.compare.SoapMockResponseNameComparat
 import com.castlemock.web.mock.soap.utility.config.AddressLocationConfigurer;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
@@ -395,15 +392,12 @@ public abstract class AbstractSoapServiceController extends AbstractController{
         String body = mockResponse.getBody();
         if(mockResponse.isUsingExpressions()){
 
-            final ExpressionArgument<?> bodyArgument = new ExpressionArgumentString(request.getBody());
-            final ExpressionArgument<?> urlArgument = new ExpressionArgumentString(httpServletRequest.getRequestURL().toString());
-            final Map<String, ExpressionArgument<?>> externalInput =
-                    ImmutableMap.of(
-                            BodyXPathExpression.BODY_ARGUMENT, bodyArgument,
-                            UrlHostExpression.URL_ARGUMENT, urlArgument
-                    );
+            final Map<String, ExpressionArgument<?>> externalInput = new ExternalInputBuilder()
+                    .requestUrl(httpServletRequest.getRequestURL().toString())
+                    .requestBody(request.getBody())
+                    .build();
 
-            body = TextParser.parse(body, externalInput);
+            body = new TextParser().parse(body, externalInput);
         }
         return SoapResponse.builder()
                 .body(body)


### PR DESCRIPTION
This pull request fixes https://github.com/castlemock/castlemock/issues/197.
With this changes, the response time with usingExpressions=True takes < 1 seconds (around 350 miliseconds), using the given usingExpressions.zip file.

The main change is the refactory of the `TextParser.parse(String, Map)` method to use `StringBuilder` instead of `regex` to make text find and replace.

Adictional changes was made to facilitate testing. Examples are:
- Creation of `ExternalInputBuilder` class, using code that was in `AbstractRestServiceController` and `AbstractSoapServiceController`
- Creation of `TextParseMockConfig`, a test utility class used by `TextParserTest` class
- Creation of the several new test methods in `TextParserTest` class.
- Construtors in `TextParser` to allow predictable expression results in `TextParserTest` tests methods.