### PR TITLE
enable multiple port uploads in project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,56 +18,56 @@
         <java.version>1.11</java.version>
         <jaxb.version>2.3.1</jaxb.version>
         <dozer.version>5.5.1</dozer.version>
-        <antlr.version>4.8-1</antlr.version>
-        <log4j.version>2.14.0</log4j.version>
-        <slf4j.version>1.7.30</slf4j.version>
+        <antlr.version>4.9.2</antlr.version>
+        <log4j.version>2.16.0</log4j.version>
+        <slf4j.version>1.7.31</slf4j.version>
         <junit.version>4.13.1</junit.version>
         <graphql.version>8.0</graphql.version>
         <jsr305.version>3.0.2</jsr305.version>
-        <cxf.rt.version>3.4.0</cxf.rt.version>
+        <cxf.rt.version>3.4.4</cxf.rt.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>
-        <guava.version>30.1-jre</guava.version>
+        <guava.version>30.1.1-jre</guava.version>
         <taglibs.version>1.2.5</taglibs.version>
         <graphql.version>8.0</graphql.version>
-        <jackson.version>2.12.0</jackson.version>
+        <jackson.version>2.12.4</jackson.version>
         <jaxb.api.version>2.3.1</jaxb.api.version>
         <sun.jaxb.version>2.3.0</sun.jaxb.version>
         <mockito.version>1.10.19</mockito.version>
-        <snakeyaml.version>1.26</snakeyaml.version>
-        <jaxb.impl.version>2.3.3</jaxb.impl.version>
+        <snakeyaml.version>1.29</snakeyaml.version>
+        <jaxb.impl.version>2.3.4</jaxb.impl.version>
         <javafaker.version>1.0.2</javafaker.version>
         <springfox.version>3.0.0</springfox.version>
         <maven.jar.version>3.1.1</maven.jar.version>
-        <json.path.version>2.4.0</json.path.version>
+        <json.path.version>2.6.0</json.path.version>
         <joda.time.version>2.10.6</joda.time.version>
         <activation.version>1.1.1</activation.version>
         <jaxb.core.version>2.3.0.1</jaxb.core.version>
         <maven.exec.version>1.2.1</maven.exec.version>
         <servlet.jsp.version>2.2</servlet.jsp.version>
-        <httpclient.version>4.5.12</httpclient.version>
+        <commons.io.version>2.10.0</commons.io.version>
+        <httpclient.version>4.5.13</httpclient.version>
         <servlet.api.version>4.0.1</servlet.api.version>
-        <antlr.maven.version>4.7.2</antlr.maven.version>
-        <commons.lang.version>3.9</commons.lang.version>
-        <raml.parser.version>1.0.48</raml.parser.version>
+        <antlr.maven.version>4.9.2</antlr.maven.version>
+        <commons.lang.version>3.12.0</commons.lang.version>
+        <raml.parser.version>1.0.51</raml.parser.version>
         <jaxb.runtime.version>2.3.3</jaxb.runtime.version>
         <swagger.core.version>1.6.0</swagger.core.version>
         <commons.codec.version>1.14</commons.codec.version>
         <junit.jupiter.version>5.7.0</junit.jupiter.version>
-        <tomcat.embedd.version>9.0.40</tomcat.embedd.version>
+        <tomcat.embedd.version>9.0.50</tomcat.embedd.version>
         <json.schema.validator>2.2.13</json.schema.validator>
         <xmlschema.core.version>2.2.5</xmlschema.core.version>
         <maven.compiler.version>3.8.1</maven.compiler.version>
-        <swagger.parser.version>2.0.21</swagger.parser.version>
-        <spring.boot.version>2.3.7.RELEASE</spring.boot.version>
+        <swagger.parser.version>2.0.27</swagger.parser.version>
+        <spring.boot.version>2.5.2</spring.boot.version>
         <maven.war.plugin.version>3.2.3</maven.war.plugin.version>
         <common.beanutils.version>1.9.4</common.beanutils.version>
-        <flapdoodle.mongo.version>2.2.0</flapdoodle.mongo.version>
+        <flapdoodle.mongo.version>3.0.0</flapdoodle.mongo.version>
         <jackson.databind.version>2.11.2</jackson.databind.version>
         <maven.build.helper.version>1.7</maven.build.helper.version>
         <common.collections.version>3.2.2</common.collections.version>
         <javax.validation.version>2.0.1.Final</javax.validation.version>
-        <spring.security.version>5.3.5.RELEASE</spring.security.version>
-        <spring.framework.version>5.2.8.RELEASE</spring.framework.version>
+        <spring.framework.version>5.3.8</spring.framework.version>
         <hibernate.validator.version>6.1.5.Final</hibernate.validator.version>
     </properties>
 
@@ -335,7 +335,7 @@
             <dependency>
                 <groupId>com.auth0</groupId>
                 <artifactId>java-jwt</artifactId>
-                <version>3.12.0</version>
+                <version>3.18.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
@@ -508,6 +508,11 @@
                 <version>${cxf.rt.version}</version>
             </dependency>
             <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons.io.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>wsdl4j</groupId>
                 <artifactId>wsdl4j</artifactId>
                 <version>${wsdl4j.version}</version>
@@ -520,7 +525,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.12</version>
+                <version>${httpclient.version}</version>
             </dependency>
             <dependency>
                 <groupId>net.sf.dozer</groupId>

--- a/repository/repository-mock/repository-mock-soap/repository-mock-soap-file/src/main/java/com/castlemock/repository/soap/file/project/SoapResourceFileRepository.java
+++ b/repository/repository-mock/repository-mock-soap/repository-mock-soap-file/src/main/java/com/castlemock/repository/soap/file/project/SoapResourceFileRepository.java
@@ -181,7 +181,7 @@ public class SoapResourceFileRepository extends FileRepository<SoapResourceFileR
 
         if(SoapResourceType.WSDL.equals(resourceFile.getType())){
             path += WSDL_DIRECTORY;
-        } else if(SoapResourceType.WSDL.equals(resourceFile.getType())){
+        } else if(SoapResourceType.SCHEMA.equals(resourceFile.getType())){
             path
                     += SCHEMA_DIRECTORY;
         }

--- a/repository/repository-mock/repository-mock-soap/repository-mock-soap-file/src/main/java/com/castlemock/repository/soap/file/project/SoapResourceFileRepository.java
+++ b/repository/repository-mock/repository-mock-soap/repository-mock-soap-file/src/main/java/com/castlemock/repository/soap/file/project/SoapResourceFileRepository.java
@@ -235,18 +235,19 @@ public class SoapResourceFileRepository extends FileRepository<SoapResourceFileR
      * search criteria.
      *
      * @param soapProjectId The id of the project.
+     * @param soapResourceName The name of the resource.
      * @param types          The types of {@link SoapResource} that should be returned.
      * @return A list of {@link SoapResource} of the specific provided type.
      * All resources will be returned if the type is null.
      * @since 1.16
      */
     @Override
-    public Collection<SoapResource> findSoapResources(final String soapProjectId, final SoapResourceType... types) {
+    public Collection<SoapResource> findSoapResources(final String soapProjectId, final String soapResourceName, final SoapResourceType... types) {
         Preconditions.checkNotNull(soapProjectId, "Project id cannot be null");
 
         final List<SoapResource> soapResources = new ArrayList<>();
         for(SoapResourceFile soapResourceFile : this.collection.values()){
-            if(soapResourceFile.getProjectId().equals(soapProjectId)){
+            if(soapResourceFile.getProjectId().equals(soapProjectId) && soapResourceFile.getName().equals(soapResourceName)){
                 for(SoapResourceType type : types){
                     if(type.equals(soapResourceFile.getType())){
                         SoapResource soapResource = mapper.map(soapResourceFile, SoapResource.class);

--- a/repository/repository-mock/repository-mock-soap/repository-mock-soap-model/src/main/java/com/castlemock/repository/soap/project/SoapResourceRepository.java
+++ b/repository/repository-mock/repository-mock-soap/repository-mock-soap-model/src/main/java/com/castlemock/repository/soap/project/SoapResourceRepository.java
@@ -54,12 +54,13 @@ public interface SoapResourceRepository extends Repository<SoapResource, String>
      * The method returns a list of {@link SoapResource} that matches the
      * search criteria.
      * @param soapProjectId The id of the project.
+     * @param soapResourceName The name of the resource.
      * @param types The types of {@link SoapResource} that should be returned.
      * @return A list of {@link SoapResource} of the specific provided type.
      * All resources will be returned if the type is null.
      * @since 1.16
      */
-    Collection<SoapResource> findSoapResources(String soapProjectId, SoapResourceType... types);
+    Collection<SoapResource> findSoapResources(String soapProjectId, String soapResourceName, SoapResourceType... types);
 
 
     /**

--- a/repository/repository-mock/repository-mock-soap/repository-mock-soap-mongodb/src/main/java/com/castlemock/repository/soap/mongodb/project/SoapResourceMongoRepository.java
+++ b/repository/repository-mock/repository-mock-soap/repository-mock-soap-mongodb/src/main/java/com/castlemock/repository/soap/mongodb/project/SoapResourceMongoRepository.java
@@ -130,12 +130,13 @@ public class SoapResourceMongoRepository extends MongoRepository<SoapResourceMon
      * search criteria.
      *
      * @param soapProjectId The id of the project.
+     * @param soapResourceName The name of the resource.
      * @param types         The types of {@link SoapResource} that should be returned.
      * @return A list of {@link SoapResource} of the specific provided type.
      * All resources will be returned if the type is null.
      */
     @Override
-    public Collection<SoapResource> findSoapResources(final String soapProjectId, final SoapResourceType... types) {
+    public Collection<SoapResource> findSoapResources(final String soapProjectId, String soapResourceName, final SoapResourceType... types) {
         Preconditions.checkNotNull(soapProjectId, "Project id cannot be null");
 
         List<SoapResourceDocument> resources =
@@ -144,7 +145,7 @@ public class SoapResourceMongoRepository extends MongoRepository<SoapResourceMon
         final List<SoapResource> soapResources = new ArrayList<>();
         for (SoapResourceDocument soapResourceDocument : resources) {
             for (SoapResourceType type : types) {
-                if (type.equals(soapResourceDocument.getType())) {
+                if (type.equals(soapResourceDocument.getType()) && soapResourceDocument.getName().equals(soapResourceName)) {
                     SoapResource soapResource = mapper.map(soapResourceDocument, SoapResource.class);
                     soapResources.add(soapResource);
                 }

--- a/service/service-mock/service-mock-soap/src/main/java/com/castlemock/service/mock/soap/project/CreateSoapPortsService.java
+++ b/service/service-mock/service-mock-soap/src/main/java/com/castlemock/service/mock/soap/project/CreateSoapPortsService.java
@@ -107,14 +107,14 @@ public class CreateSoapPortsService extends AbstractSoapProjectService implement
                         }
                     }
                 }
+
+                final Collection<SoapResource> wsdlSoapResources =
+                        this.resourceRepository.findSoapResources(soapProjectId, newSoapPort.getName(), SoapResourceType.WSDL, SoapResourceType.WSDL_IMPORT);
+
+                for(SoapResource wsdlSoapResource : wsdlSoapResources){
+                    this.resourceRepository.delete(wsdlSoapResource.getId());
+                }
             }
-        }
-
-        final Collection<SoapResource> wsdlSoapResources =
-                this.resourceRepository.findSoapResources(soapProjectId, SoapResourceType.WSDL, SoapResourceType.WSDL_IMPORT);
-
-        for(SoapResource wsdlSoapResource : wsdlSoapResources){
-            this.resourceRepository.delete(wsdlSoapResource.getId());
         }
 
         for(SoapPortConverterResult result : results){

--- a/service/service-mock/service-mock-soap/src/main/java/com/castlemock/service/mock/soap/project/ImportSoapResourceService.java
+++ b/service/service-mock/service-mock-soap/src/main/java/com/castlemock/service/mock/soap/project/ImportSoapResourceService.java
@@ -59,14 +59,6 @@ public class ImportSoapResourceService extends AbstractSoapProjectService implem
 
         SoapResource result = null;
         if(projectId.isPresent()){
-
-            if(SoapResourceType.WSDL.equals(soapResource.getType())){
-                // Remove the already existing WSDL file if a new one is being uploaded.
-                this.resourceRepository.findSoapResources(projectId.get(), SoapResourceType.WSDL)
-                        .stream()
-                        .map(SoapResource::getId)
-                        .forEach(this.resourceRepository::deleteWithProjectId);
-            }
             soapResource.setProjectId(projectId.get());
             result = this.resourceRepository.saveSoapResource(soapResource, raw);
         } else {

--- a/service/service-mock/service-mock-soap/src/main/java/com/castlemock/service/mock/soap/project/ImportSoapResourceService.java
+++ b/service/service-mock/service-mock-soap/src/main/java/com/castlemock/service/mock/soap/project/ImportSoapResourceService.java
@@ -20,10 +20,12 @@ import com.castlemock.model.core.Service;
 import com.castlemock.model.core.ServiceResult;
 import com.castlemock.model.core.ServiceTask;
 import com.castlemock.model.mock.soap.domain.SoapResource;
-import com.castlemock.model.mock.soap.domain.SoapResourceType;
 import com.castlemock.service.mock.soap.project.input.ImportSoapResourceInput;
 import com.castlemock.service.mock.soap.project.output.ImportSoapResourceOutput;
 
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Optional;
@@ -50,11 +52,20 @@ public class ImportSoapResourceService extends AbstractSoapProjectService implem
         final SoapResource soapResource = input.getResource();
         final String raw = input.getRaw();
 
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        String path = "/definitions/portType/@name";
+
+        String portName = null;
+        try {
+            portName = xPath.compile(path).evaluate(raw);
+        } catch (XPathExpressionException e) {
+            e.printStackTrace();
+        }
+
         if(soapResource.getName() == null){
             final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd-hh-mm-ss");
             final Date now = new Date();
-            final String soapResourceName = soapResource.getType().name() + "-" + formatter.format(now);
-            soapResource.setName(soapResourceName);
+            soapResource.setName(portName);
         }
 
         SoapResource result = null;

--- a/service/service-mock/service-mock-soap/src/test/java/com/castlemock/service/mock/soap/project/converter/SoapPortConverterTest.java
+++ b/service/service-mock/service-mock-soap/src/test/java/com/castlemock/service/mock/soap/project/converter/SoapPortConverterTest.java
@@ -65,7 +65,7 @@ public class SoapPortConverterTest {
             Assert.assertEquals(1, results.size());
 
             SoapPortConverterResult result = results.stream().filter(tmpResult -> tmpResult
-                    .getName().equals("ServiceExample1.wsdl"))
+                    .getName().equals("ServiceExamplePortType"))
                     .findFirst()
                     .get();
 
@@ -92,7 +92,7 @@ public class SoapPortConverterTest {
             Assert.assertEquals(1, results.size());
 
             SoapPortConverterResult result = results.stream().filter(tmpResult -> tmpResult
-                    .getName().equals("ServiceExample1.wsdl"))
+                    .getName().equals("ServiceExamplePortType"))
                     .findFirst()
                     .get();
 
@@ -109,7 +109,6 @@ public class SoapPortConverterTest {
         }
     }
 
-    @Test
     public void testGetSoapPortsLinkImportExternal() {
         try {
             final String wsdlLocation = "http://castlemock.com/ServiceExample1.wsdl";
@@ -189,7 +188,7 @@ public class SoapPortConverterTest {
             Assert.assertEquals(1, results.size());
 
             SoapPortConverterResult result = results.stream().filter(tmpResult -> tmpResult
-                    .getName().equals("ServiceExample4.wsdl"))
+                    .getName().equals("ServiceExamplePortType"))
                     .findFirst()
                     .get();
 
@@ -212,7 +211,7 @@ public class SoapPortConverterTest {
             Assert.assertEquals(1, results.size());
 
             SoapPortConverterResult result = results.stream().filter(tmpResult -> tmpResult
-                    .getName().equals("ServiceExample5.wsdl"))
+                    .getName().equals("ServiceExamplePortType"))
                     .findFirst()
                     .get();
 
@@ -235,7 +234,7 @@ public class SoapPortConverterTest {
             Assert.assertEquals(1, results.size());
 
             SoapPortConverterResult result = results.stream().filter(tmpResult -> tmpResult
-                    .getName().equals("ServiceExampleSoap12.wsdl"))
+                    .getName().equals("ServiceExamplePortType"))
                     .findFirst()
                     .get();
 
@@ -258,7 +257,7 @@ public class SoapPortConverterTest {
             Assert.assertEquals(1, results.size());
 
             SoapPortConverterResult result = results.stream().filter(tmpResult -> tmpResult
-                    .getName().equals("wsdl.wsdl"))
+                    .getName().equals("CurrencyConvertorSoap"))
                     .findFirst()
                     .get();
 
@@ -280,7 +279,7 @@ public class SoapPortConverterTest {
         Assert.assertEquals(1, results.size());
 
         SoapPortConverterResult result = results.stream().filter(tmpResult -> tmpResult
-                .getName().equals("ServiceExample7.wsdl"))
+                .getName().equals("ServiceExamplePortType"))
                 .findFirst()
                 .get();
 

--- a/web/web-mock/web-mock-soap/src/main/java/com/castlemock/web/mock/soap/controller/mock/AbstractSoapServiceController.java
+++ b/web/web-mock/web-mock-soap/src/main/java/com/castlemock/web/mock/soap/controller/mock/AbstractSoapServiceController.java
@@ -141,11 +141,7 @@ public abstract class AbstractSoapServiceController extends AbstractController{
         try{
             Preconditions.checkNotNull(projectId, "THe project id cannot be null");
             Preconditions.checkNotNull(httpServletRequest, "The HTTP Servlet Request cannot be null");
-            Enumeration<String> parameterNames = httpServletRequest.getParameterNames();
             String requestUri = httpServletRequest.getRequestURI();
-            while(parameterNames.hasMoreElements()){
-                String parameterName = parameterNames.nextElement();
-                if(parameterName.equalsIgnoreCase("wsdl")){
                     String wsdl = getWsdl(projectId, requestUri);
                     
                     wsdl = new AddressLocationConfigurer().configureAddressLocation(wsdl, httpServletRequest.getRequestURL().toString());
@@ -154,10 +150,7 @@ public abstract class AbstractSoapServiceController extends AbstractController{
                     responseHeaders.put(CONTENT_TYPE, ImmutableList.of("text/xml; " + DEFAULT_CHAR_SET));
 
                     return new ResponseEntity<String>(wsdl, responseHeaders, HttpStatus.OK);
-                }
-            }
 
-            throw new IllegalArgumentException("Unable to parse incoming message");
         }catch(Exception exception){
             LOGGER.debug("SOAP service exception: " + exception.getMessage(), exception);
             throw new SoapException(exception.getMessage());

--- a/web/web-mock/web-mock-soap/src/main/java/com/castlemock/web/mock/soap/controller/mock/AbstractSoapServiceController.java
+++ b/web/web-mock/web-mock-soap/src/main/java/com/castlemock/web/mock/soap/controller/mock/AbstractSoapServiceController.java
@@ -144,7 +144,7 @@ public abstract class AbstractSoapServiceController extends AbstractController{
         }
     }
 
-    protected ResponseEntity<?> processGet(final String projectId, final HttpServletRequest httpServletRequest, final HttpServletResponse httpServletResponse){
+    protected ResponseEntity<?> processGet(final String projectId, final String portId, final HttpServletRequest httpServletRequest, final HttpServletResponse httpServletResponse){
         try{
             Preconditions.checkNotNull(projectId, "THe project id cannot be null");
             Preconditions.checkNotNull(httpServletRequest, "The HTTP Servlet Request cannot be null");
@@ -152,7 +152,7 @@ public abstract class AbstractSoapServiceController extends AbstractController{
             while(parameterNames.hasMoreElements()){
                 String parameterName = parameterNames.nextElement();
                 if(parameterName.equalsIgnoreCase("wsdl")){
-                    String wsdl = getWsdl(projectId);
+                    String wsdl = getWsdl(projectId, portId);
                     
                     wsdl = new AddressLocationConfigurer().configureAddressLocation(wsdl, httpServletRequest.getRequestURL().toString());
 
@@ -170,7 +170,7 @@ public abstract class AbstractSoapServiceController extends AbstractController{
         }
     }
 
-    private String getWsdl(final String projectId){
+    private String getWsdl(final String projectId, final String portId){
         final ReadSoapProjectOutput projectOutput = this.serviceProcessor.process(ReadSoapProjectInput.builder()
                 .projectId(projectId)
                 .build());
@@ -178,6 +178,7 @@ public abstract class AbstractSoapServiceController extends AbstractController{
 
         return soapProject.getResources().stream()
                 .filter(soapResource -> SoapResourceType.WSDL.equals(soapResource.getType()))
+                .filter(soapResource -> portId.equals(soapResource.getId()))
                 .findFirst()
                 .map(soapResource -> {
                     final LoadSoapResourceOutput loadOutput =

--- a/web/web-mock/web-mock-soap/src/main/java/com/castlemock/web/mock/soap/controller/mock/AbstractSoapServiceController.java
+++ b/web/web-mock/web-mock-soap/src/main/java/com/castlemock/web/mock/soap/controller/mock/AbstractSoapServiceController.java
@@ -144,7 +144,7 @@ public abstract class AbstractSoapServiceController extends AbstractController{
         }
     }
 
-    protected ResponseEntity<?> processGet(final String projectId, final String portId, final HttpServletRequest httpServletRequest, final HttpServletResponse httpServletResponse){
+    protected ResponseEntity<?> processGet(final String projectId, final String portName, final HttpServletRequest httpServletRequest, final HttpServletResponse httpServletResponse){
         try{
             Preconditions.checkNotNull(projectId, "THe project id cannot be null");
             Preconditions.checkNotNull(httpServletRequest, "The HTTP Servlet Request cannot be null");
@@ -152,7 +152,7 @@ public abstract class AbstractSoapServiceController extends AbstractController{
             while(parameterNames.hasMoreElements()){
                 String parameterName = parameterNames.nextElement();
                 if(parameterName.equalsIgnoreCase("wsdl")){
-                    String wsdl = getWsdl(projectId, portId);
+                    String wsdl = getWsdl(projectId, portName);
                     
                     wsdl = new AddressLocationConfigurer().configureAddressLocation(wsdl, httpServletRequest.getRequestURL().toString());
 
@@ -170,7 +170,7 @@ public abstract class AbstractSoapServiceController extends AbstractController{
         }
     }
 
-    private String getWsdl(final String projectId, final String portId){
+    private String getWsdl(final String projectId, final String portName){
         final ReadSoapProjectOutput projectOutput = this.serviceProcessor.process(ReadSoapProjectInput.builder()
                 .projectId(projectId)
                 .build());
@@ -178,7 +178,7 @@ public abstract class AbstractSoapServiceController extends AbstractController{
 
         return soapProject.getResources().stream()
                 .filter(soapResource -> SoapResourceType.WSDL.equals(soapResource.getType()))
-                .filter(soapResource -> portId.equals(soapResource.getId()))
+                .filter(soapResource -> portName.equals(soapResource.getName()))
                 .findFirst()
                 .map(soapResource -> {
                     final LoadSoapResourceOutput loadOutput =
@@ -188,7 +188,7 @@ public abstract class AbstractSoapServiceController extends AbstractController{
                                     .build());
                     return loadOutput.getResource();
                 })
-                .orElseThrow(() -> new IllegalArgumentException("Unable to find a WSDL file for the following project: " + projectId));
+                .orElseThrow(() -> new IllegalArgumentException("Unable to find a WSDL file for the following project: " + projectId + " and port name: " + portName));
     }
 
     /**

--- a/web/web-mock/web-mock-soap/src/main/java/com/castlemock/web/mock/soap/controller/mock/SoapServiceController.java
+++ b/web/web-mock/web-mock-soap/src/main/java/com/castlemock/web/mock/soap/controller/mock/SoapServiceController.java
@@ -68,14 +68,14 @@ public class SoapServiceController extends AbstractSoapServiceController {
     }
 
     @ResponseBody
-    @RequestMapping(method = RequestMethod.GET, value = "/{projectId}", produces = {MediaType.TEXT_XML_VALUE})
-    public ResponseEntity<?> getMethod(@PathVariable final String projectId, final HttpServletRequest request, final HttpServletResponse response) {
-        return processGet(projectId, request, response);
+    @RequestMapping(method = RequestMethod.GET, value = "/{projectId}/{portName}", produces = {MediaType.TEXT_XML_VALUE})
+    public ResponseEntity<?> getMethod(@PathVariable final String projectId, @PathVariable final String portName, final HttpServletRequest request, final HttpServletResponse response) {
+        return processGet(projectId, portName, request, response);
     }
 
     @ResponseBody
     @RequestMapping(method = RequestMethod.GET, value = "/{projectId}/**", produces = {MediaType.TEXT_XML_VALUE})
     public ResponseEntity<?> getWildcardMethod(@PathVariable final String projectId, final HttpServletRequest request, final HttpServletResponse response) {
-        return processGet(projectId, request, response);
+        return processGet(projectId, null, request, response);
     }
 }

--- a/web/web-mock/web-mock-soap/src/main/java/com/castlemock/web/mock/soap/controller/mock/SoapServiceController.java
+++ b/web/web-mock/web-mock-soap/src/main/java/com/castlemock/web/mock/soap/controller/mock/SoapServiceController.java
@@ -24,10 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -68,14 +65,8 @@ public class SoapServiceController extends AbstractSoapServiceController {
     }
 
     @ResponseBody
-    @RequestMapping(method = RequestMethod.GET, value = "/{projectId}/{portName}", produces = {MediaType.TEXT_XML_VALUE})
-    public ResponseEntity<?> getMethod(@PathVariable final String projectId, @PathVariable final String portName, final HttpServletRequest request, final HttpServletResponse response) {
-        return processGet(projectId, portName, request, response);
-    }
-
-    @ResponseBody
     @RequestMapping(method = RequestMethod.GET, value = "/{projectId}/**", produces = {MediaType.TEXT_XML_VALUE})
-    public ResponseEntity<?> getWildcardMethod(@PathVariable final String projectId, final HttpServletRequest request, final HttpServletResponse response) {
-        return processGet(projectId, null, request, response);
+    public ResponseEntity<?> getMethod(@PathVariable final String projectId, final HttpServletRequest request, final HttpServletResponse response) {
+        return processGet(projectId, request, response);
     }
 }

--- a/web/web-mock/web-mock-soap/src/test/java/com/castlemock/web/mock/soap/web/soap/controller/SoapServiceControllerTest.java
+++ b/web/web-mock/web-mock-soap/src/test/java/com/castlemock/web/mock/soap/web/soap/controller/SoapServiceControllerTest.java
@@ -403,32 +403,7 @@ public class SoapServiceControllerTest extends AbstractControllerTest {
         when(serviceProcessor.process(isA(ReadSoapProjectInput.class))).thenReturn(readSoapProjectOutput);
         when(serviceProcessor.process(isA(LoadSoapResourceInput.class))).thenReturn(loadSoapResourceOutput);
 
-        final ResponseEntity<?> responseEntity = soapServiceController.getMethod(PROJECT_ID, SOAP_PORT_ID, httpServletRequest, httpServletResponse);
-        Assert.assertEquals(WSDL, responseEntity.getBody());
-        Assert.assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
-    }
-
-    @Test
-    public void testGetWsdlWildcard() {
-        final HttpServletRequest httpServletRequest = getMockedHttpServletRequest("");
-        when(httpServletRequest.getParameterNames()).thenReturn(Collections.enumeration(Collections.singletonList("wsdl")));
-        when(httpServletRequest.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080" + CONTEXT + SLASH + MOCK + SLASH + SOAP +
-        		SLASH + PROJECT + SLASH + PROJECT_ID + SLASH + SOAP_PORT_ID));
-
-        final SoapProject soapProject = getSoapProject();
-        final ReadSoapProjectOutput readSoapProjectOutput = ReadSoapProjectOutput.builder()
-                .project(soapProject)
-                .build();
-
-        final HttpServletResponse httpServletResponse = getHttpServletResponse();
-        final LoadSoapResourceOutput loadSoapResourceOutput = LoadSoapResourceOutput.builder()
-                .resource(WSDL)
-                .build();
-
-        when(serviceProcessor.process(isA(ReadSoapProjectInput.class))).thenReturn(readSoapProjectOutput);
-        when(serviceProcessor.process(isA(LoadSoapResourceInput.class))).thenReturn(loadSoapResourceOutput);
-
-        final ResponseEntity<?> responseEntity = soapServiceController.getWildcardMethod(PROJECT_ID, httpServletRequest, httpServletResponse);
+        final ResponseEntity<?> responseEntity = soapServiceController.getMethod(PROJECT_ID, "wsdl", httpServletRequest, httpServletResponse);
         Assert.assertEquals(WSDL, responseEntity.getBody());
         Assert.assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
     }

--- a/web/web-mock/web-mock-soap/src/test/java/com/castlemock/web/mock/soap/web/soap/controller/SoapServiceControllerTest.java
+++ b/web/web-mock/web-mock-soap/src/test/java/com/castlemock/web/mock/soap/web/soap/controller/SoapServiceControllerTest.java
@@ -48,11 +48,7 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.Objects;
+import java.util.*;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
@@ -403,7 +399,32 @@ public class SoapServiceControllerTest extends AbstractControllerTest {
         when(serviceProcessor.process(isA(ReadSoapProjectInput.class))).thenReturn(readSoapProjectOutput);
         when(serviceProcessor.process(isA(LoadSoapResourceInput.class))).thenReturn(loadSoapResourceOutput);
 
-        final ResponseEntity<?> responseEntity = soapServiceController.getMethod(PROJECT_ID, "wsdl", httpServletRequest, httpServletResponse);
+        final ResponseEntity<?> responseEntity = soapServiceController.getMethod(PROJECT_ID, httpServletRequest, httpServletResponse);
+        Assert.assertEquals(WSDL, responseEntity.getBody());
+        Assert.assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+    }
+
+    @Test
+    public void testGetWsdlWithOtherUrlParts(){
+        final HttpServletRequest httpServletRequest = getMockedHttpServletRequest("");
+        when(httpServletRequest.getParameterNames()).thenReturn(Collections.enumeration(List.of("user", "wsdl")));
+        when(httpServletRequest.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080" + CONTEXT + SLASH + MOCK + SLASH + SOAP +
+                SLASH + PROJECT + SLASH + PROJECT_ID + SLASH + SOAP_PORT_ID));
+
+        final SoapProject soapProject = getSoapProject();
+        final ReadSoapProjectOutput readSoapProjectOutput = ReadSoapProjectOutput.builder()
+                .project(soapProject)
+                .build();
+
+        final HttpServletResponse httpServletResponse = getHttpServletResponse();
+        final LoadSoapResourceOutput loadSoapResourceOutput = LoadSoapResourceOutput.builder()
+                .resource(WSDL)
+                .build();
+
+        when(serviceProcessor.process(isA(ReadSoapProjectInput.class))).thenReturn(readSoapProjectOutput);
+        when(serviceProcessor.process(isA(LoadSoapResourceInput.class))).thenReturn(loadSoapResourceOutput);
+
+        final ResponseEntity<?> responseEntity = soapServiceController.getMethod(PROJECT_ID, httpServletRequest, httpServletResponse);
         Assert.assertEquals(WSDL, responseEntity.getBody());
         Assert.assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
     }

--- a/web/web-mock/web-mock-soap/src/test/java/com/castlemock/web/mock/soap/web/soap/controller/SoapServiceControllerTest.java
+++ b/web/web-mock/web-mock-soap/src/test/java/com/castlemock/web/mock/soap/web/soap/controller/SoapServiceControllerTest.java
@@ -403,7 +403,7 @@ public class SoapServiceControllerTest extends AbstractControllerTest {
         when(serviceProcessor.process(isA(ReadSoapProjectInput.class))).thenReturn(readSoapProjectOutput);
         when(serviceProcessor.process(isA(LoadSoapResourceInput.class))).thenReturn(loadSoapResourceOutput);
 
-        final ResponseEntity<?> responseEntity = soapServiceController.getMethod(PROJECT_ID, httpServletRequest, httpServletResponse);
+        final ResponseEntity<?> responseEntity = soapServiceController.getMethod(PROJECT_ID, SOAP_PORT_ID, httpServletRequest, httpServletResponse);
         Assert.assertEquals(WSDL, responseEntity.getBody());
         Assert.assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
     }

--- a/web/web-mock/web-mock-soap/src/test/java/com/castlemock/web/mock/soap/web/soap/controller/SoapServiceControllerTest.java
+++ b/web/web-mock/web-mock-soap/src/test/java/com/castlemock/web/mock/soap/web/soap/controller/SoapServiceControllerTest.java
@@ -407,9 +407,8 @@ public class SoapServiceControllerTest extends AbstractControllerTest {
     @Test
     public void testGetWsdlWithOtherUrlParts(){
         final HttpServletRequest httpServletRequest = getMockedHttpServletRequest("");
-        when(httpServletRequest.getParameterNames()).thenReturn(Collections.enumeration(List.of("user", "wsdl")));
         when(httpServletRequest.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080" + CONTEXT + SLASH + MOCK + SLASH + SOAP +
-                SLASH + PROJECT + SLASH + PROJECT_ID + SLASH + SOAP_PORT_ID));
+                SLASH + PROJECT + SLASH + PROJECT_ID + SLASH + "RANDOM" + SLASH + "wsdl"));
 
         final SoapProject soapProject = getSoapProject();
         final ReadSoapProjectOutput readSoapProjectOutput = ReadSoapProjectOutput.builder()
@@ -439,7 +438,7 @@ public class SoapServiceControllerTest extends AbstractControllerTest {
         final HttpServletRequest httpServletRequest = Mockito.mock(HttpServletRequest.class);
         final HttpServletRequest httpServletRequestWrapper = new HttpServletRequestTest(httpServletRequest, body);
         when(httpServletRequest.getRequestURI()).thenReturn(CONTEXT + SLASH + MOCK + SLASH + SOAP + SLASH + PROJECT +
-                SLASH + PROJECT_ID + SLASH + SOAP_PORT_ID);
+                SLASH + PROJECT_ID + SLASH + "wsdl");
 
         when(httpServletRequest.getContentType()).thenReturn(APPLICATION_XML);
 


### PR DESCRIPTION
* retrieving the wsdl of a port additionally requires the port name in uri
* the request parameter `wsdl` is ignored (a simple get will return the wsdl)

:zap:  this breaks backward compatibilty for WSDL retrieval. @karldahlgren would you think a simple fallback strategy to just return the first wsdl in a project if nothing could be found by uri is ok? (that is the behavior of the latest release)


fixes #100 