### PR TITLE
Fixes enconding problem in SOAP Mock Response

### DIFF
--- a/deploy/deploy-jetty/deploy-jetty-jar/src/test/java/com/castlemock/deploy/jetty/jar/FileRepositorySupportTest.java
+++ b/deploy/deploy-jetty/deploy-jetty-jar/src/test/java/com/castlemock/deploy/jetty/jar/FileRepositorySupportTest.java
@@ -4,13 +4,17 @@ import com.castlemock.repository.core.file.FileRepository;
 import com.castlemock.repository.core.file.FileRepositorySupport;
 import com.castlemock.repository.soap.file.project.SoapMockResponseFileRepository;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public class FileRepositorySupportTest {
 
     @Test
-    public void testSave(){
+    public void testSave() throws IOException{
         final FileRepositorySupport fileRepositorySupport = new FileRepositorySupport();
         final FileRepository.HttpHeaderFile httpHeaderFile = new FileRepository.HttpHeaderFile();
         final SoapMockResponseFileRepository.SoapMockResponseFile soapMockResponseFile = new SoapMockResponseFileRepository.SoapMockResponseFile();
@@ -35,7 +39,7 @@ public class FileRepositorySupportTest {
                 "\n" +
                 "<soap:Body>\n" +
                 "  <m:GetPrice xmlns:m=\"https://www.w3schools.com/prices\">\n" +
-                "    <m:Item>Apples</m:Item>\n" +
+                "    <m:Item>Apples Maçãs</m:Item>\n" +
                 "  </m:GetPrice>\n" +
                 "</soap:Body>\n" +
                 "\n" +
@@ -43,8 +47,14 @@ public class FileRepositorySupportTest {
         soapMockResponseFile.setHttpHeaders(headers);
         soapMockResponseFile.setXpathExpressions(expressions);
 
-        // TODO Resolve test
-        //fileRepositorySupport.save(soapMockResponseFile, "/home/karl/.castlemock/soap/response/v2/0qirU2.res");
+        Path saveFilePath = Files.createTempFile(null, ".res");
+        
+        fileRepositorySupport.save(soapMockResponseFile, saveFilePath.toString());
+        String savedContent = fileRepositorySupport.load(saveFilePath.getParent().toString(), saveFilePath.getFileName().toString());
+        
+        Assertions.assertTrue(savedContent.contains("Apples Maçãs"));
+        
+        Files.deleteIfExists(saveFilePath);
     }
 
 }

--- a/repository/repository-core/repository-core-file/src/main/java/com/castlemock/repository/core/file/FileRepositorySupport.java
+++ b/repository/repository-core/repository-core-file/src/main/java/com/castlemock/repository/core/file/FileRepositorySupport.java
@@ -88,7 +88,7 @@ public class FileRepositorySupport {
 
         BufferedWriter writer = null;
         try {
-            writer = new BufferedWriter(new FileWriter(file));
+            writer = new BufferedWriter(new FileWriter(file, StandardCharsets.UTF_8));
             writer.write(data);
         } catch (Exception e) {
             LOGGER.error("Unable to save the following file: " + filename, e);
@@ -140,7 +140,7 @@ public class FileRepositorySupport {
             final JAXBContext context = JAXBContext.newInstance(type.getClass());
             final Marshaller marshaller = context.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-            writer = new FileWriter(filename);
+            writer = new FileWriter(filename, StandardCharsets.UTF_8);
             marshaller.marshal(type, writer);
         } catch (JAXBException e) {
             LOGGER.error("Unable to parse file: " + filename, e);

--- a/repository/repository-core/repository-core-file/src/main/java/com/castlemock/repository/core/file/token/SessionTokenFileRepository.java
+++ b/repository/repository-core/repository-core-file/src/main/java/com/castlemock/repository/core/file/token/SessionTokenFileRepository.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -148,7 +149,7 @@ public class SessionTokenFileRepository implements SessionTokenRepository {
             JAXBContext context = JAXBContext.newInstance(SessionTokenList.class);
             Marshaller marshaller = context.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-            writer = new FileWriter(filename);
+            writer = new FileWriter(filename, StandardCharsets.UTF_8);
             marshaller.marshal(tokens, writer);
         } catch (JAXBException e) {
             LOGGER.error("Unable to parse the following file: " + tokenFileName, e);


### PR DESCRIPTION
Hi, @karldahlgren! This pull request fixes https://github.com/castlemock/castlemock/issues/284.

The solution consists of replace `new FileWriter(file)` by `new FileWriter(file, StandardCharsets.UTF_8)`.

