### PR TITLE
NEW: Add capability to import from OpenAPI v3 specifications and generate mocks

### DIFF
--- a/model/model-mock/model-mock-rest/src/main/java/com/castlemock/model/mock/rest/RestDefinitionType.java
+++ b/model/model-mock/model-mock-rest/src/main/java/com/castlemock/model/mock/rest/RestDefinitionType.java
@@ -22,7 +22,7 @@ package com.castlemock.model.mock.rest;
  */
 public enum RestDefinitionType {
 
-    SWAGGER("Swagger"), WADL("WADL"), RAML("RAML");
+    SWAGGER("Swagger"), OPENAPI("Openapi"), WADL("WADL"), RAML("RAML");
 
 
     private final String displayName;

--- a/model/model-mock/model-mock-rest/src/main/java/com/castlemock/model/mock/rest/RestDefinitionType.java
+++ b/model/model-mock/model-mock-rest/src/main/java/com/castlemock/model/mock/rest/RestDefinitionType.java
@@ -22,7 +22,7 @@ package com.castlemock.model.mock.rest;
  */
 public enum RestDefinitionType {
 
-    SWAGGER("Swagger"), OPENAPI("Openapi"), WADL("WADL"), RAML("RAML");
+    SWAGGER("Swagger"), OPENAPI("OpenAPI"), WADL("WADL"), RAML("RAML");
 
 
     private final String displayName;

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Project properties -->
-        <project.version>1.70</project.version>
+        <project.version>1.64</project.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -59,7 +59,7 @@
         <xmlschema.core.version>2.2.5</xmlschema.core.version>
         <maven.compiler.version>3.8.1</maven.compiler.version>
         <spring.boot.version>2.7.8</spring.boot.version>
-        <swagger.parser.version>2.1.12</swagger.parser.version>
+        <swagger.parser.version>2.1.9</swagger.parser.version>
         <maven.war.plugin.version>3.2.3</maven.war.plugin.version>
         <common.beanutils.version>1.9.4</common.beanutils.version>
         <jackson.databind.version>2.11.2</jackson.databind.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Project properties -->
-        <project.version>1.64</project.version>
+        <project.version>1.70</project.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -59,7 +59,7 @@
         <xmlschema.core.version>2.2.5</xmlschema.core.version>
         <maven.compiler.version>3.8.1</maven.compiler.version>
         <spring.boot.version>2.7.8</spring.boot.version>
-        <swagger.parser.version>2.1.9</swagger.parser.version>
+        <swagger.parser.version>2.1.12</swagger.parser.version>
         <maven.war.plugin.version>3.2.3</maven.war.plugin.version>
         <common.beanutils.version>1.9.4</common.beanutils.version>
         <jackson.databind.version>2.11.2</jackson.databind.version>

--- a/service/service-mock/service-mock-rest/src/main/java/com/castlemock/service/mock/rest/project/converter/RestDefinitionConverterFactory.java
+++ b/service/service-mock/service-mock-rest/src/main/java/com/castlemock/service/mock/rest/project/converter/RestDefinitionConverterFactory.java
@@ -19,6 +19,7 @@ package com.castlemock.service.mock.rest.project.converter;
 
 import com.castlemock.model.mock.rest.RestDefinitionType;
 import com.castlemock.service.core.manager.FileManager;
+import com.castlemock.service.mock.rest.project.converter.openapi.OpenApiRestDefinitionConverter;
 import com.castlemock.service.mock.rest.project.converter.raml.RAMLRestDefinitionConverter;
 import com.castlemock.service.mock.rest.project.converter.swagger.SwaggerRestDefinitionConverter;
 import com.castlemock.service.mock.rest.project.converter.wadl.WADLRestDefinitionConverter;
@@ -53,6 +54,8 @@ public final class RestDefinitionConverterFactory {
                 return new WADLRestDefinitionConverter(fileManager);
             case SWAGGER:
                 return new SwaggerRestDefinitionConverter();
+            case OPENAPI:
+                return new OpenApiRestDefinitionConverter();
             case RAML:
                 return new RAMLRestDefinitionConverter();
         }

--- a/service/service-mock/service-mock-rest/src/main/java/com/castlemock/service/mock/rest/project/converter/openapi/OpenApiRestDefinitionConverter.java
+++ b/service/service-mock/service-mock-rest/src/main/java/com/castlemock/service/mock/rest/project/converter/openapi/OpenApiRestDefinitionConverter.java
@@ -153,7 +153,7 @@ public class OpenApiRestDefinitionConverter extends AbstractRestDefinitionConver
      */
     private String getForwardAddress(final OpenAPI openAPI) {
         if (!openAPI.getServers().isEmpty() && openAPI.getServers().get(0).getUrl() != null) {
-            openAPI.getServers().get(0).getUrl();
+            return openAPI.getServers().get(0).getUrl();
         }
         return Strings.EMPTY;
     }
@@ -269,7 +269,6 @@ public class OpenApiRestDefinitionConverter extends AbstractRestDefinitionConver
                 String headerName = headerEntry.getKey();
                 HttpHeader httpHeader = new HttpHeader();
                 httpHeader.setName(headerName);
-                // Swagger does not include an example value for the response.
                 restMockResponse.getHttpHeaders().add(httpHeader);
             }
         }

--- a/service/service-mock/service-mock-rest/src/main/java/com/castlemock/service/mock/rest/project/converter/openapi/OpenApiRestDefinitionConverter.java
+++ b/service/service-mock/service-mock-rest/src/main/java/com/castlemock/service/mock/rest/project/converter/openapi/OpenApiRestDefinitionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Karl Dahlgren
+ * Copyright 2023 Jebish Moses
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,11 +29,16 @@ import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import io.swagger.v3.parser.core.models.ParseOptions;
 import joptsimple.internal.Strings;
 import org.apache.commons.lang3.ObjectUtils;
 
 import java.io.File;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
 
 /**
  * The {@link OpenApiRestDefinitionConverter} provides OpenAPI V3 related functionality.
@@ -49,8 +54,11 @@ public class OpenApiRestDefinitionConverter extends AbstractRestDefinitionConver
      */
     @Override
     public List<RestApplication> convert(final File file, final boolean generateResponse) {
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setResolve(true);
+        parseOptions.setResolveFully(true);
         final String openApiContent = FileUtility.getFileContent(file);
-        SwaggerParseResult result = new OpenAPIParser().readContents(openApiContent, null, null);
+        SwaggerParseResult result = new OpenAPIParser().readContents(openApiContent, null, parseOptions);
         OpenAPI openAPI = result.getOpenAPI();
         final RestApplication restApplication = convertOpenApi(openAPI, generateResponse);
         return List.of(restApplication);
@@ -66,7 +74,10 @@ public class OpenApiRestDefinitionConverter extends AbstractRestDefinitionConver
      */
     @Override
     public List<RestApplication> convert(final String location, final boolean generateResponse) {
-        SwaggerParseResult result = new OpenAPIParser().readLocation(location, null, null);
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setResolve(true);
+        parseOptions.setResolveFully(true);
+        final SwaggerParseResult result = new OpenAPIParser().readLocation(location, null, parseOptions);
         OpenAPI openAPI = result.getOpenAPI();
         final RestApplication restApplication = convertOpenApi(openAPI, generateResponse);
         return List.of(restApplication);
@@ -297,3 +308,4 @@ public class OpenApiRestDefinitionConverter extends AbstractRestDefinitionConver
                 "from the following swagger config: " + openAPI);
     }
 }
+

--- a/service/service-mock/service-mock-rest/src/main/java/com/castlemock/service/mock/rest/project/converter/openapi/OpenApiRestDefinitionConverter.java
+++ b/service/service-mock/service-mock-rest/src/main/java/com/castlemock/service/mock/rest/project/converter/openapi/OpenApiRestDefinitionConverter.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2017 Karl Dahlgren
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.castlemock.service.mock.rest.project.converter.openapi;
+
+import com.castlemock.model.core.http.HttpHeader;
+import com.castlemock.model.core.http.HttpMethod;
+import com.castlemock.model.core.utility.file.FileUtility;
+import com.castlemock.model.mock.rest.domain.*;
+import com.castlemock.service.mock.rest.project.converter.AbstractRestDefinitionConverter;
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.headers.Header;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import joptsimple.internal.Strings;
+import org.apache.commons.lang3.ObjectUtils;
+
+import java.io.File;
+import java.util.*;
+
+/**
+ * The {@link OpenApiRestDefinitionConverter} provides OpenAPI V3 related functionality.
+ */
+public class OpenApiRestDefinitionConverter extends AbstractRestDefinitionConverter {
+    /**
+     * The convert method provides the functionality to convert the provided {@link File} into
+     * a list of {@link RestApplication}.
+     *
+     * @param file             The file which will be converted to one or more {@link RestApplication}.
+     * @param generateResponse Will generate a default response if true. No response will be generated if false.
+     * @return A list of {@link RestApplication} based on the provided file.
+     */
+    @Override
+    public List<RestApplication> convert(final File file, final boolean generateResponse) {
+        final String openApiContent = FileUtility.getFileContent(file);
+        SwaggerParseResult result = new OpenAPIParser().readContents(openApiContent, null, null);
+        OpenAPI openAPI = result.getOpenAPI();
+        final RestApplication restApplication = convertOpenApi(openAPI, generateResponse);
+        return List.of(restApplication);
+    }
+
+    /**
+     * The convert method provides the functionality to convert the provided {@link File} into
+     * a list of {@link RestApplication}.
+     *
+     * @param location         The location of the definition file
+     * @param generateResponse Will generate a default response if true. No response will be generated if false.
+     * @return A list of {@link RestApplication} based on the provided file.
+     */
+    @Override
+    public List<RestApplication> convert(final String location, final boolean generateResponse) {
+        SwaggerParseResult result = new OpenAPIParser().readLocation(location, null, null);
+        OpenAPI openAPI = result.getOpenAPI();
+        final RestApplication restApplication = convertOpenApi(openAPI, generateResponse);
+        return List.of(restApplication);
+    }
+
+
+    /**
+     * The method provides the functionality to convert a Swagger String into a {@link RestApplication}.
+     * The following HTTP methods will be extracted from the Swagger content:
+     * <ul>
+     *     <li>GET</li>
+     *     <li>PUT</li>
+     *     <li>POST</li>
+     *     <li>DELETE</li>
+     *     <li>HEAD</li>
+     *     <li>OPTIONS</li>
+     * </ul>
+     *
+     * @param openAPI          The OpenAPI content which will be generated into a {@link RestApplication}.
+     * @param generateResponse Will generate a default response if true. No response will be generated if false.
+     * @return A {@link RestApplication} based on the provided Swagger content.
+     */
+    private RestApplication convertOpenApi(final OpenAPI openAPI, final boolean generateResponse) {
+
+        if (openAPI == null) {
+            throw new IllegalArgumentException("Unable to parse the OpenApi content.");
+        }
+
+        final RestApplication restApplication = new RestApplication();
+        restApplication.setName(this.getApplicationName(openAPI));
+
+        final String forwardAddress = getForwardAddress(openAPI);
+
+        for (Map.Entry<String, PathItem> pathEntry : openAPI.getPaths().entrySet()) {
+            final String resourceName = pathEntry.getKey();
+            final PathItem resourcePath = pathEntry.getValue();
+            final RestResource restResource = new RestResource();
+
+            restResource.setName(resourceName);
+            restResource.setUri(resourceName);
+
+            if (resourcePath.getGet() != null) {
+                Operation operation = resourcePath.getGet();
+                RestMethod restMethod = createRestMethod(operation, HttpMethod.GET, forwardAddress, generateResponse);
+                restResource.getMethods().add(restMethod);
+            }
+            if (resourcePath.getPost() != null) {
+                Operation operation = resourcePath.getPost();
+                RestMethod restMethod = createRestMethod(operation, HttpMethod.POST, forwardAddress, generateResponse);
+                restResource.getMethods().add(restMethod);
+            }
+            if (resourcePath.getPut() != null) {
+                Operation operation = resourcePath.getPut();
+                RestMethod restMethod = createRestMethod(operation, HttpMethod.PUT, forwardAddress, generateResponse);
+                restResource.getMethods().add(restMethod);
+            }
+            if (resourcePath.getDelete() != null) {
+                Operation operation = resourcePath.getDelete();
+                RestMethod restMethod = createRestMethod(operation, HttpMethod.DELETE, forwardAddress, generateResponse);
+                restResource.getMethods().add(restMethod);
+            }
+            if (resourcePath.getHead() != null) {
+                Operation operation = resourcePath.getHead();
+                RestMethod restMethod = createRestMethod(operation, HttpMethod.HEAD, forwardAddress, generateResponse);
+                restResource.getMethods().add(restMethod);
+            }
+            if (resourcePath.getOptions() != null) {
+                Operation operation = resourcePath.getOptions();
+                RestMethod restMethod = createRestMethod(operation, HttpMethod.OPTIONS, forwardAddress, generateResponse);
+                restResource.getMethods().add(restMethod);
+            }
+
+            restApplication.getResources().add(restResource);
+        }
+
+        return restApplication;
+    }
+
+    /**
+     * The method extracts the forward address from the {@link OpenAPI} model.
+     *
+     * @param openAPI The {@link OpenAPI} model contains information about the source address.
+     * @return The extracted source address configured in {@link OpenAPI}.
+     */
+    private String getForwardAddress(final OpenAPI openAPI) {
+        if (!openAPI.getServers().isEmpty() && openAPI.getServers().get(0).getUrl() != null) {
+            openAPI.getServers().get(0).getUrl();
+        }
+        return Strings.EMPTY;
+    }
+
+    /**
+     * Create a {@link RestMethod} based on a Swagger {@link Operation} and a {@link HttpMethod}.
+     *
+     * @param operation        The Swagger operation that will be converted to a {@link RestMethod}.
+     * @param httpMethod       The {@link HttpMethod} of the new {@link RestMethod}.
+     * @param forwardAddress   The configured forward address. The request for this method will be forwarded to
+     *                         this address if the service is configured to be {@link RestMethodStatus#FORWARDED},
+     *                         {@link RestMethodStatus#RECORDING} or  {@link RestMethodStatus#RECORD_ONCE}
+     * @param generateResponse Will generate a default response if true. No response will be generated if false.
+     * @return A {@link RestMethod} based on the provided Swagger {@link Operation} and the {@link HttpMethod}.
+     */
+    private RestMethod createRestMethod(final Operation operation,
+                                        final HttpMethod httpMethod, final String forwardAddress,
+                                        final boolean generateResponse) {
+        final RestMethod restMethod = new RestMethod();
+
+        String methodName;
+        if (operation.getOperationId() != null) {
+            methodName = operation.getOperationId();
+        } else if (operation.getSummary() != null) {
+            methodName = operation.getSummary();
+        } else {
+            methodName = httpMethod.name();
+        }
+
+        restMethod.setHttpMethod(httpMethod);
+        restMethod.setName(methodName);
+        restMethod.setStatus(RestMethodStatus.MOCKED);
+        restMethod.setResponseStrategy(RestResponseStrategy.SEQUENCE);
+        restMethod.setForwardedEndpoint(forwardAddress);
+
+        if (generateResponse) {
+            if (ObjectUtils.isNotEmpty(operation.getResponses())) {
+                Collection<RestMockResponse> mockResponses = generateResponse(operation.getResponses());
+                restMethod.getMockResponses().addAll(mockResponses);
+            } else {
+                RestMockResponse generatedResponse = generateResponse();
+                restMethod.getMockResponses().add(generatedResponse);
+            }
+        }
+
+        return restMethod;
+    }
+
+    /**
+     * The method generates a default response.
+     *
+     * @param responses The Swagger response definitions
+     * @return The newly generated {@link RestMockResponse}.
+     */
+    private Collection<RestMockResponse> generateResponse(final ApiResponses responses) {
+        if (responses == null) {
+            return Collections.emptyList();
+        }
+
+        final List<RestMockResponse> mockResponses = new ArrayList<>();
+        for (Map.Entry<String, ApiResponse> responseEntry : responses.entrySet()) {
+            ApiResponse response = responseEntry.getValue();
+
+            int httpStatusCode = extractHttpStatusCode(responseEntry.getKey());
+
+            RestMockResponse restMockResponse = generateResponse(httpStatusCode, response);
+            mockResponses.add(restMockResponse);
+
+        }
+        return mockResponses;
+    }
+
+    /**
+     * The method will extract the HTTP response status code. The provided response code
+     * is a {@link String} and should be parsed to an integer. However, the response code
+     * is not always the actual response code. In fact, it can be anything. Therefore,
+     * upon {@link NumberFormatException} the default response code will be returned: 200.
+     *
+     * @param responseCode The response code that will be parsed into an integer.
+     * @return The parsed response code. 200 if the parsing failed.
+     */
+    private int extractHttpStatusCode(final String responseCode) {
+        try {
+            return Integer.parseInt(responseCode);
+        } catch (Exception e) {
+            return DEFAULT_RESPONSE_CODE;
+        }
+    }
+
+    /**
+     * The method generates a mocked response based on the provided {@link ApiResponse} and the
+     * <code>httpStatusCode</code>.
+     *
+     * @param httpStatusCode The HTTP status code that the mocked response will have. Please note that
+     *                       any mock response with status code different from OK (200), will be
+     *                       marked as disabled.
+     * @param response       The Swagger response that the mocked response will be based on.
+     * @return A new {@link RestMockResponse} based on the provided {@link ApiResponse}.
+     */
+    private RestMockResponse generateResponse(final int httpStatusCode, final ApiResponse response) {
+        RestMockResponse restMockResponse = new RestMockResponse();
+        restMockResponse.setName(response.getDescription());
+        restMockResponse.setHttpStatusCode(httpStatusCode);
+        restMockResponse.setUsingExpressions(true);
+        if (httpStatusCode == DEFAULT_RESPONSE_CODE) {
+            restMockResponse.setStatus(RestMockResponseStatus.ENABLED);
+        } else {
+            restMockResponse.setStatus(RestMockResponseStatus.DISABLED);
+        }
+
+        if (response.getHeaders() != null) {
+            for (Map.Entry<String, Header> headerEntry : response.getHeaders().entrySet()) {
+                String headerName = headerEntry.getKey();
+                HttpHeader httpHeader = new HttpHeader();
+                httpHeader.setName(headerName);
+                // Swagger does not include an example value for the response.
+                restMockResponse.getHttpHeaders().add(httpHeader);
+            }
+        }
+        return restMockResponse;
+    }
+
+    private String getApplicationName(final OpenAPI openAPI) {
+        if (openAPI.getInfo() != null) {
+            if (openAPI.getInfo().getTitle() != null) {
+                return openAPI.getInfo().getTitle();
+            }
+            if (openAPI.getInfo().getDescription() != null) {
+                return openAPI.getInfo().getDescription();
+            }
+        }
+        if (openAPI.getServers().size() != 0) {
+            if (openAPI.getServers().get(0).getDescription() != null) {
+                return openAPI.getServers().get(0).getDescription();
+            }
+            if (openAPI.getServers().get(0).getUrl() != null) {
+                return openAPI.getServers().get(0).getUrl();
+            }
+        }
+
+        throw new IllegalArgumentException("Unable to extract application name " +
+                "from the following swagger config: " + openAPI);
+    }
+}

--- a/service/service-mock/service-mock-rest/src/test/java/com/castlemock/service/mock/rest/project/converter/openapi/OpenApiRestDefinitionConverterTest.java
+++ b/service/service-mock/service-mock-rest/src/test/java/com/castlemock/service/mock/rest/project/converter/openapi/OpenApiRestDefinitionConverterTest.java
@@ -1,0 +1,677 @@
+package com.castlemock.service.mock.rest.project.converter.openapi;
+
+import com.castlemock.model.core.http.HttpMethod;
+import com.castlemock.model.mock.rest.domain.*;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.List;
+
+public class OpenApiRestDefinitionConverterTest {
+
+    final OpenApiRestDefinitionConverter converter = new OpenApiRestDefinitionConverter();
+
+    @Test
+    public void shouldConvertToRestApplications_givenFile() throws URISyntaxException {
+        final URL url = OpenApiRestDefinitionConverter.class.getResource("petstore.json");
+        final File file = new File(url.toURI());
+        final List<RestApplication> restApplications = converter.convert(file, false);
+        this.verifyResult(restApplications, false);
+    }
+
+    @Test
+    public void shouldConvertToRestApplications_givenFile_WithGenerateResponseTrue() throws URISyntaxException {
+        final URL url = OpenApiRestDefinitionConverter.class.getResource("petstore.json");
+        final File file = new File(url.toURI());
+        final List<RestApplication> restApplications = converter.convert(file, true);
+        this.verifyResult(restApplications, true);
+    }
+
+    @Test
+    public void shouldThrowError_givenOpenAPINull() throws URISyntaxException {
+        final URL url = OpenApiRestDefinitionConverter.class.getResource("petstore_empty.json");
+        final File file = new File(url.toURI());
+        IllegalArgumentException actualException = Assert.assertThrows(IllegalArgumentException.class, () -> converter.convert(file, false));
+        String expectedExceptionMessage = "Unable to parse the OpenApi content.";
+        Assert.assertEquals(actualException.getMessage(), expectedExceptionMessage);
+    }
+
+    @Test
+    public void shouldConvertToRestApplications_givenMalformedFile() throws URISyntaxException {
+        final URL url = OpenApiRestDefinitionConverter.class.getResource("petstore_malformed_openapi.json");
+        final File file = new File(url.toURI());
+        final List<RestApplication> restApplications = converter.convert(file, true);
+        this.verifyResultForMalformedFile(restApplications, true);
+    }
+
+    private void verifyResult(final List<RestApplication> restApplications,
+                              final boolean generatedResponse) {
+
+        Assert.assertNotNull(restApplications);
+        Assert.assertEquals(1, restApplications.size());
+
+        final RestApplication restApplication = restApplications.get(0);
+
+        Assert.assertEquals("Swagger Petstore - OpenAPI 3.0", restApplication.getName());
+        Assert.assertNull(restApplication.getId());
+        Assert.assertNull(restApplication.getProjectId());
+        Assert.assertEquals(2, restApplication.getResources().size());
+
+
+        // /pet
+        final RestResource mockResource = restApplication.getResources().stream()
+                .filter(resource -> resource.getName().equals("/pet"))
+                .findFirst()
+                .get();
+
+        Assert.assertNotNull(mockResource);
+        Assert.assertEquals("/pet", mockResource.getName());
+        Assert.assertEquals("/pet", mockResource.getUri());
+        Assert.assertNull(mockResource.getId());
+        Assert.assertNull(mockResource.getApplicationId());
+        Assert.assertNull(mockResource.getInvokeAddress());
+
+        // /pet (PUT) - updatePet
+
+        RestMethod updatePetRestMethod = mockResource.getMethods().stream()
+                .filter(method -> method.getName().equals("updatePet"))
+                .findFirst()
+                .get();
+
+        Assert.assertNotNull(updatePetRestMethod);
+        Assert.assertEquals("updatePet", updatePetRestMethod.getName());
+        Assert.assertEquals("/api/v3", updatePetRestMethod.getForwardedEndpoint());
+        Assert.assertEquals(HttpMethod.PUT, updatePetRestMethod.getHttpMethod());
+        Assert.assertEquals(RestMethodStatus.MOCKED, updatePetRestMethod.getStatus());
+        Assert.assertEquals(RestResponseStrategy.SEQUENCE, updatePetRestMethod.getResponseStrategy());
+        Assert.assertEquals(Integer.valueOf(0), updatePetRestMethod.getCurrentResponseSequenceIndex());
+        Assert.assertEquals(0L, updatePetRestMethod.getNetworkDelay());
+        Assert.assertFalse(updatePetRestMethod.getSimulateNetworkDelay());
+        Assert.assertNull(updatePetRestMethod.getDefaultBody());
+        Assert.assertNull(updatePetRestMethod.getId());
+        Assert.assertNull(updatePetRestMethod.getResourceId());
+
+        if (generatedResponse) {
+            Assert.assertEquals(4, updatePetRestMethod.getMockResponses().size());
+
+            // 200
+            RestMockResponse response = updatePetRestMethod.getMockResponses().stream()
+                    .filter(method -> method.getName().equals("Successful operation"))
+                    .findFirst()
+                    .get();
+
+            Assert.assertEquals("Successful operation", response.getName());
+
+            Assert.assertEquals(Integer.valueOf(200), response.getHttpStatusCode());
+            Assert.assertEquals(RestMockResponseStatus.ENABLED, response.getStatus());
+            Assert.assertTrue(response.isUsingExpressions());
+            Assert.assertTrue(response.getContentEncodings().isEmpty());
+            Assert.assertNull(response.getId());
+            Assert.assertNull(response.getMethodId());
+
+
+            // 400
+            RestMockResponse invalidMockResponse = updatePetRestMethod.getMockResponses().stream()
+                    .filter(method -> method.getName().equals("Invalid ID supplied"))
+                    .findFirst()
+                    .get();
+
+            Assert.assertEquals("Invalid ID supplied", invalidMockResponse.getName());
+            Assert.assertNull(invalidMockResponse.getBody());
+
+            Assert.assertEquals(Integer.valueOf(400), invalidMockResponse.getHttpStatusCode());
+            Assert.assertEquals(RestMockResponseStatus.DISABLED, invalidMockResponse.getStatus());
+            Assert.assertTrue(invalidMockResponse.isUsingExpressions());
+            Assert.assertTrue(invalidMockResponse.getContentEncodings().isEmpty());
+            Assert.assertNull(invalidMockResponse.getId());
+            Assert.assertNull(invalidMockResponse.getMethodId());
+            Assert.assertEquals(0, invalidMockResponse.getHttpHeaders().size());
+
+            // 404
+            RestMockResponse notFoundResponse = updatePetRestMethod.getMockResponses().stream()
+                    .filter(method -> method.getName().equals("Pet not found"))
+                    .findFirst()
+                    .get();
+
+            Assert.assertEquals("Pet not found", notFoundResponse.getName());
+            Assert.assertNull(notFoundResponse.getBody());
+
+            Assert.assertEquals(Integer.valueOf(404), notFoundResponse.getHttpStatusCode());
+            Assert.assertEquals(RestMockResponseStatus.DISABLED, notFoundResponse.getStatus());
+            Assert.assertTrue(notFoundResponse.isUsingExpressions());
+            Assert.assertTrue(notFoundResponse.getContentEncodings().isEmpty());
+            Assert.assertNull(notFoundResponse.getId());
+            Assert.assertNull(notFoundResponse.getMethodId());
+            Assert.assertEquals(0, notFoundResponse.getHttpHeaders().size());
+
+            // 405
+            RestMockResponse validationExceptionResponse = updatePetRestMethod.getMockResponses().stream()
+                    .filter(method -> method.getName().equals("Validation exception"))
+                    .findFirst()
+                    .get();
+
+            Assert.assertEquals("Validation exception", validationExceptionResponse.getName());
+            Assert.assertNull(validationExceptionResponse.getBody());
+
+            Assert.assertEquals(Integer.valueOf(405), validationExceptionResponse.getHttpStatusCode());
+            Assert.assertEquals(RestMockResponseStatus.DISABLED, validationExceptionResponse.getStatus());
+            Assert.assertTrue(validationExceptionResponse.isUsingExpressions());
+            Assert.assertTrue(validationExceptionResponse.getContentEncodings().isEmpty());
+            Assert.assertNull(validationExceptionResponse.getId());
+            Assert.assertNull(validationExceptionResponse.getMethodId());
+            Assert.assertEquals(0, validationExceptionResponse.getHttpHeaders().size());
+        } else {
+            Assert.assertEquals(0, updatePetRestMethod.getMockResponses().size());
+        }
+
+
+        // /pet (POST) - addPet
+
+        RestMethod addPetRestMethod = mockResource.getMethods().stream()
+                .filter(method -> method.getName().equals("addPet"))
+                .findFirst()
+                .get();
+
+        Assert.assertNotNull(addPetRestMethod);
+        Assert.assertEquals("addPet", addPetRestMethod.getName());
+        Assert.assertEquals("/api/v3", addPetRestMethod.getForwardedEndpoint());
+        Assert.assertEquals(HttpMethod.POST, addPetRestMethod.getHttpMethod());
+        Assert.assertEquals(RestMethodStatus.MOCKED, addPetRestMethod.getStatus());
+        Assert.assertEquals(RestResponseStrategy.SEQUENCE, addPetRestMethod.getResponseStrategy());
+        Assert.assertEquals(Integer.valueOf(0), addPetRestMethod.getCurrentResponseSequenceIndex());
+        Assert.assertEquals(0L, addPetRestMethod.getNetworkDelay());
+        Assert.assertFalse(addPetRestMethod.getSimulateNetworkDelay());
+        Assert.assertNull(addPetRestMethod.getDefaultBody());
+        Assert.assertNull(addPetRestMethod.getId());
+        Assert.assertNull(addPetRestMethod.getResourceId());
+
+        if (generatedResponse) {
+            Assert.assertEquals(2, addPetRestMethod.getMockResponses().size());
+
+            // 200
+            RestMockResponse response = addPetRestMethod.getMockResponses().stream()
+                    .filter(method -> method.getName().equals("Successful operation"))
+                    .findFirst()
+                    .get();
+
+            Assert.assertEquals("Successful operation", response.getName());
+
+            Assert.assertEquals(Integer.valueOf(200), response.getHttpStatusCode());
+            Assert.assertEquals(RestMockResponseStatus.ENABLED, response.getStatus());
+            Assert.assertTrue(response.isUsingExpressions());
+            Assert.assertTrue(response.getContentEncodings().isEmpty());
+            Assert.assertNull(response.getId());
+            Assert.assertNull(response.getMethodId());
+
+            // 405
+            RestMockResponse invalidMockResponse = addPetRestMethod.getMockResponses().stream()
+                    .filter(method -> method.getName().equals("Invalid input"))
+                    .findFirst()
+                    .get();
+
+            Assert.assertEquals("Invalid input", invalidMockResponse.getName());
+            Assert.assertNull(invalidMockResponse.getBody());
+
+            Assert.assertEquals(Integer.valueOf(405), invalidMockResponse.getHttpStatusCode());
+            Assert.assertEquals(RestMockResponseStatus.DISABLED, invalidMockResponse.getStatus());
+            Assert.assertTrue(invalidMockResponse.isUsingExpressions());
+            Assert.assertTrue(invalidMockResponse.getContentEncodings().isEmpty());
+            Assert.assertNull(invalidMockResponse.getId());
+            Assert.assertNull(invalidMockResponse.getMethodId());
+            Assert.assertEquals(0, invalidMockResponse.getHttpHeaders().size());
+
+        } else {
+            Assert.assertEquals(0, addPetRestMethod.getMockResponses().size());
+        }
+
+        // /pet/{petId}
+        final RestResource petWithParameterResource = restApplication.getResources().stream()
+                .filter(resource -> resource.getName().equals("/pet/{petId}"))
+                .findFirst()
+                .get();
+
+        Assert.assertNotNull(petWithParameterResource);
+        Assert.assertEquals("/pet/{petId}", petWithParameterResource.getName());
+        Assert.assertEquals("/pet/{petId}", petWithParameterResource.getUri());
+        Assert.assertNull(petWithParameterResource.getId());
+        Assert.assertNull(petWithParameterResource.getApplicationId());
+        Assert.assertNull(petWithParameterResource.getInvokeAddress());
+
+        // /mock/{mockId} (GET) - getMockById
+
+        RestMethod getPetByIdMethod = petWithParameterResource.getMethods().stream()
+                .filter(method -> method.getName().equals("getPetById"))
+                .findFirst()
+                .get();
+
+        Assert.assertNotNull(getPetByIdMethod);
+        Assert.assertEquals("getPetById", getPetByIdMethod.getName());
+        Assert.assertEquals("/api/v3", getPetByIdMethod.getForwardedEndpoint());
+        Assert.assertEquals(HttpMethod.GET, getPetByIdMethod.getHttpMethod());
+        Assert.assertEquals(RestMethodStatus.MOCKED, getPetByIdMethod.getStatus());
+        Assert.assertEquals(RestResponseStrategy.SEQUENCE, getPetByIdMethod.getResponseStrategy());
+        Assert.assertEquals(Integer.valueOf(0), getPetByIdMethod.getCurrentResponseSequenceIndex());
+        Assert.assertEquals(0L, getPetByIdMethod.getNetworkDelay());
+        Assert.assertFalse(getPetByIdMethod.getSimulateNetworkDelay());
+        Assert.assertNull(getPetByIdMethod.getDefaultBody());
+        Assert.assertNull(getPetByIdMethod.getId());
+        Assert.assertNull(getPetByIdMethod.getResourceId());
+
+        if (generatedResponse) {
+            Assert.assertEquals(3, getPetByIdMethod.getMockResponses().size());
+
+            // 200
+            RestMockResponse response = getPetByIdMethod.getMockResponses().stream()
+                    .filter(method -> method.getName().equals("successful operation"))
+                    .findFirst()
+                    .get();
+
+            Assert.assertEquals("successful operation", response.getName());
+
+            Assert.assertEquals(Integer.valueOf(200), response.getHttpStatusCode());
+            Assert.assertEquals(RestMockResponseStatus.ENABLED, response.getStatus());
+            Assert.assertTrue(response.isUsingExpressions());
+            Assert.assertTrue(response.getContentEncodings().isEmpty());
+            Assert.assertNull(response.getId());
+            Assert.assertNull(response.getMethodId());
+
+
+            // 400
+            RestMockResponse invalidMockResponse = getPetByIdMethod.getMockResponses().stream()
+                    .filter(method -> method.getName().equals("Invalid ID supplied"))
+                    .findFirst()
+                    .get();
+
+            Assert.assertEquals("Invalid ID supplied", invalidMockResponse.getName());
+            Assert.assertNull(invalidMockResponse.getBody());
+
+            Assert.assertEquals(Integer.valueOf(400), invalidMockResponse.getHttpStatusCode());
+            Assert.assertEquals(RestMockResponseStatus.DISABLED, invalidMockResponse.getStatus());
+            Assert.assertTrue(invalidMockResponse.isUsingExpressions());
+            Assert.assertTrue(invalidMockResponse.getContentEncodings().isEmpty());
+            Assert.assertNull(invalidMockResponse.getId());
+            Assert.assertNull(invalidMockResponse.getMethodId());
+            Assert.assertEquals(0, invalidMockResponse.getHttpHeaders().size());
+
+            // 404
+            RestMockResponse notFoundResponse = getPetByIdMethod.getMockResponses().stream()
+                    .filter(method -> method.getName().equals("Pet not found"))
+                    .findFirst()
+                    .get();
+
+            Assert.assertEquals("Pet not found", notFoundResponse.getName());
+            Assert.assertNull(notFoundResponse.getBody());
+
+            Assert.assertEquals(Integer.valueOf(404), notFoundResponse.getHttpStatusCode());
+            Assert.assertEquals(RestMockResponseStatus.DISABLED, notFoundResponse.getStatus());
+            Assert.assertTrue(notFoundResponse.isUsingExpressions());
+            Assert.assertTrue(notFoundResponse.getContentEncodings().isEmpty());
+            Assert.assertNull(notFoundResponse.getId());
+            Assert.assertNull(notFoundResponse.getMethodId());
+            Assert.assertEquals(0, notFoundResponse.getHttpHeaders().size());
+        } else {
+            Assert.assertEquals(0, getPetByIdMethod.getMockResponses().size());
+        }
+
+
+        // /pet/{petId} (DELETE) - deletePet
+
+        RestMethod deletePetMethod = petWithParameterResource.getMethods().stream()
+                .filter(method -> method.getName().equals("deletePet"))
+                .findFirst()
+                .get();
+
+        Assert.assertNotNull(deletePetMethod);
+        Assert.assertEquals("deletePet", deletePetMethod.getName());
+        Assert.assertEquals("/api/v3", deletePetMethod.getForwardedEndpoint());
+        Assert.assertEquals(HttpMethod.DELETE, deletePetMethod.getHttpMethod());
+        Assert.assertEquals(RestMethodStatus.MOCKED, deletePetMethod.getStatus());
+        Assert.assertEquals(RestResponseStrategy.SEQUENCE, deletePetMethod.getResponseStrategy());
+        Assert.assertEquals(Integer.valueOf(0), deletePetMethod.getCurrentResponseSequenceIndex());
+        Assert.assertEquals(0L, deletePetMethod.getNetworkDelay());
+        Assert.assertFalse(deletePetMethod.getSimulateNetworkDelay());
+        Assert.assertNull(deletePetMethod.getDefaultBody());
+        Assert.assertNull(deletePetMethod.getId());
+        Assert.assertNull(deletePetMethod.getResourceId());
+
+        if (generatedResponse) {
+            Assert.assertEquals(1, deletePetMethod.getMockResponses().size());
+
+            // 400
+            RestMockResponse invalidMockResponse = deletePetMethod.getMockResponses().stream()
+                    .filter(method -> method.getName().equals("Invalid pet value"))
+                    .findFirst()
+                    .get();
+
+            Assert.assertEquals("Invalid pet value", invalidMockResponse.getName());
+            Assert.assertNull(invalidMockResponse.getBody());
+
+            Assert.assertEquals(Integer.valueOf(400), invalidMockResponse.getHttpStatusCode());
+            Assert.assertEquals(RestMockResponseStatus.DISABLED, invalidMockResponse.getStatus());
+            Assert.assertTrue(invalidMockResponse.isUsingExpressions());
+            Assert.assertTrue(invalidMockResponse.getContentEncodings().isEmpty());
+            Assert.assertNull(invalidMockResponse.getId());
+            Assert.assertNull(invalidMockResponse.getMethodId());
+            Assert.assertEquals(0, invalidMockResponse.getHttpHeaders().size());
+        } else {
+            Assert.assertEquals(0, deletePetMethod.getMockResponses().size());
+        }
+    }
+
+    private void verifyResultForMalformedFile(final List<RestApplication> restApplications,
+                              final boolean generatedResponse) {
+
+        Assert.assertNotNull(restApplications);
+        Assert.assertEquals(1, restApplications.size());
+
+        final RestApplication restApplication = restApplications.get(0);
+
+        Assert.assertEquals("/api/v3", restApplication.getName());
+        Assert.assertNull(restApplication.getId());
+        Assert.assertNull(restApplication.getProjectId());
+        Assert.assertEquals(2, restApplication.getResources().size());
+
+
+        // /pet
+        final RestResource mockResource = restApplication.getResources().stream()
+                .filter(resource -> resource.getName().equals("/pet"))
+                .findFirst()
+                .get();
+
+        Assert.assertNotNull(mockResource);
+        Assert.assertEquals("/pet", mockResource.getName());
+        Assert.assertEquals("/pet", mockResource.getUri());
+        Assert.assertNull(mockResource.getId());
+        Assert.assertNull(mockResource.getApplicationId());
+        Assert.assertNull(mockResource.getInvokeAddress());
+
+        // /pet (PUT) - updatePet
+
+        RestMethod updatePetRestMethod = mockResource.getMethods().stream()
+                .filter(method -> method.getName().equals("Update an existing pet"))
+                .findFirst()
+                .get();
+
+        Assert.assertNotNull(updatePetRestMethod);
+        Assert.assertEquals("Update an existing pet", updatePetRestMethod.getName());
+        Assert.assertEquals("/api/v3", updatePetRestMethod.getForwardedEndpoint());
+        Assert.assertEquals(HttpMethod.PUT, updatePetRestMethod.getHttpMethod());
+        Assert.assertEquals(RestMethodStatus.MOCKED, updatePetRestMethod.getStatus());
+        Assert.assertEquals(RestResponseStrategy.SEQUENCE, updatePetRestMethod.getResponseStrategy());
+        Assert.assertEquals(Integer.valueOf(0), updatePetRestMethod.getCurrentResponseSequenceIndex());
+        Assert.assertEquals(0L, updatePetRestMethod.getNetworkDelay());
+        Assert.assertFalse(updatePetRestMethod.getSimulateNetworkDelay());
+        Assert.assertNull(updatePetRestMethod.getDefaultBody());
+        Assert.assertNull(updatePetRestMethod.getId());
+        Assert.assertNull(updatePetRestMethod.getResourceId());
+
+        if (generatedResponse) {
+            Assert.assertEquals(4, updatePetRestMethod.getMockResponses().size());
+
+            // 200
+            RestMockResponse response = updatePetRestMethod.getMockResponses().stream()
+                    .filter(method -> method.getName().equals("Successful operation"))
+                    .findFirst()
+                    .get();
+
+            Assert.assertEquals("Successful operation", response.getName());
+
+            Assert.assertEquals(Integer.valueOf(200), response.getHttpStatusCode());
+            Assert.assertEquals(RestMockResponseStatus.ENABLED, response.getStatus());
+            Assert.assertTrue(response.isUsingExpressions());
+            Assert.assertTrue(response.getContentEncodings().isEmpty());
+            Assert.assertNull(response.getId());
+            Assert.assertNull(response.getMethodId());
+
+
+            // 400
+            RestMockResponse invalidMockResponse = updatePetRestMethod.getMockResponses().stream()
+                    .filter(method -> method.getName().equals("Invalid ID supplied"))
+                    .findFirst()
+                    .get();
+
+            Assert.assertEquals("Invalid ID supplied", invalidMockResponse.getName());
+            Assert.assertNull(invalidMockResponse.getBody());
+
+            Assert.assertEquals(Integer.valueOf(400), invalidMockResponse.getHttpStatusCode());
+            Assert.assertEquals(RestMockResponseStatus.DISABLED, invalidMockResponse.getStatus());
+            Assert.assertTrue(invalidMockResponse.isUsingExpressions());
+            Assert.assertTrue(invalidMockResponse.getContentEncodings().isEmpty());
+            Assert.assertNull(invalidMockResponse.getId());
+            Assert.assertNull(invalidMockResponse.getMethodId());
+            Assert.assertEquals(0, invalidMockResponse.getHttpHeaders().size());
+
+            // 404
+            RestMockResponse notFoundResponse = updatePetRestMethod.getMockResponses().stream()
+                    .filter(method -> method.getName().equals("Pet not found"))
+                    .findFirst()
+                    .get();
+
+            Assert.assertEquals("Pet not found", notFoundResponse.getName());
+            Assert.assertNull(notFoundResponse.getBody());
+
+            Assert.assertEquals(Integer.valueOf(404), notFoundResponse.getHttpStatusCode());
+            Assert.assertEquals(RestMockResponseStatus.DISABLED, notFoundResponse.getStatus());
+            Assert.assertTrue(notFoundResponse.isUsingExpressions());
+            Assert.assertTrue(notFoundResponse.getContentEncodings().isEmpty());
+            Assert.assertNull(notFoundResponse.getId());
+            Assert.assertNull(notFoundResponse.getMethodId());
+            Assert.assertEquals(0, notFoundResponse.getHttpHeaders().size());
+
+            // 405
+            RestMockResponse validationExceptionResponse = updatePetRestMethod.getMockResponses().stream()
+                    .filter(method -> method.getName().equals("Validation exception"))
+                    .findFirst()
+                    .get();
+
+            Assert.assertEquals("Validation exception", validationExceptionResponse.getName());
+            Assert.assertNull(validationExceptionResponse.getBody());
+
+            Assert.assertEquals(Integer.valueOf(405), validationExceptionResponse.getHttpStatusCode());
+            Assert.assertEquals(RestMockResponseStatus.DISABLED, validationExceptionResponse.getStatus());
+            Assert.assertTrue(validationExceptionResponse.isUsingExpressions());
+            Assert.assertTrue(validationExceptionResponse.getContentEncodings().isEmpty());
+            Assert.assertNull(validationExceptionResponse.getId());
+            Assert.assertNull(validationExceptionResponse.getMethodId());
+            Assert.assertEquals(0, validationExceptionResponse.getHttpHeaders().size());
+        } else {
+            Assert.assertEquals(0, updatePetRestMethod.getMockResponses().size());
+        }
+
+
+        // /pet (POST) - addPet
+
+        RestMethod addPetRestMethod = mockResource.getMethods().stream()
+                .filter(method -> method.getName().equals("addPet"))
+                .findFirst()
+                .get();
+
+        Assert.assertNotNull(addPetRestMethod);
+        Assert.assertEquals("addPet", addPetRestMethod.getName());
+        Assert.assertEquals("/api/v3", addPetRestMethod.getForwardedEndpoint());
+        Assert.assertEquals(HttpMethod.POST, addPetRestMethod.getHttpMethod());
+        Assert.assertEquals(RestMethodStatus.MOCKED, addPetRestMethod.getStatus());
+        Assert.assertEquals(RestResponseStrategy.SEQUENCE, addPetRestMethod.getResponseStrategy());
+        Assert.assertEquals(Integer.valueOf(0), addPetRestMethod.getCurrentResponseSequenceIndex());
+        Assert.assertEquals(0L, addPetRestMethod.getNetworkDelay());
+        Assert.assertFalse(addPetRestMethod.getSimulateNetworkDelay());
+        Assert.assertNull(addPetRestMethod.getDefaultBody());
+        Assert.assertNull(addPetRestMethod.getId());
+        Assert.assertNull(addPetRestMethod.getResourceId());
+
+        if (generatedResponse) {
+            Assert.assertEquals(2, addPetRestMethod.getMockResponses().size());
+
+            // 200
+            RestMockResponse response = addPetRestMethod.getMockResponses().stream()
+                    .filter(method -> method.getName().equals("Successful operation"))
+                    .findFirst()
+                    .get();
+
+            Assert.assertEquals("Successful operation", response.getName());
+
+            Assert.assertEquals(Integer.valueOf(200), response.getHttpStatusCode());
+            Assert.assertEquals(RestMockResponseStatus.ENABLED, response.getStatus());
+            Assert.assertTrue(response.isUsingExpressions());
+            Assert.assertTrue(response.getContentEncodings().isEmpty());
+            Assert.assertNull(response.getId());
+            Assert.assertNull(response.getMethodId());
+
+            // 405
+            RestMockResponse invalidMockResponse = addPetRestMethod.getMockResponses().stream()
+                    .filter(method -> method.getName().equals("Invalid input"))
+                    .findFirst()
+                    .get();
+
+            Assert.assertEquals("Invalid input", invalidMockResponse.getName());
+            Assert.assertNull(invalidMockResponse.getBody());
+
+            Assert.assertEquals(Integer.valueOf(405), invalidMockResponse.getHttpStatusCode());
+            Assert.assertEquals(RestMockResponseStatus.DISABLED, invalidMockResponse.getStatus());
+            Assert.assertTrue(invalidMockResponse.isUsingExpressions());
+            Assert.assertTrue(invalidMockResponse.getContentEncodings().isEmpty());
+            Assert.assertNull(invalidMockResponse.getId());
+            Assert.assertNull(invalidMockResponse.getMethodId());
+            Assert.assertEquals(0, invalidMockResponse.getHttpHeaders().size());
+
+        } else {
+            Assert.assertEquals(0, addPetRestMethod.getMockResponses().size());
+        }
+
+        // /pet/{petId}
+        final RestResource petWithParameterResource = restApplication.getResources().stream()
+                .filter(resource -> resource.getName().equals("/pet/{petId}"))
+                .findFirst()
+                .get();
+
+        Assert.assertNotNull(petWithParameterResource);
+        Assert.assertEquals("/pet/{petId}", petWithParameterResource.getName());
+        Assert.assertEquals("/pet/{petId}", petWithParameterResource.getUri());
+        Assert.assertNull(petWithParameterResource.getId());
+        Assert.assertNull(petWithParameterResource.getApplicationId());
+        Assert.assertNull(petWithParameterResource.getInvokeAddress());
+
+        // /mock/{mockId} (GET) - getMockById
+
+        RestMethod getPetByIdMethod = petWithParameterResource.getMethods().stream()
+                .filter(method -> method.getName().equals("getPetById"))
+                .findFirst()
+                .get();
+
+        Assert.assertNotNull(getPetByIdMethod);
+        Assert.assertEquals("getPetById", getPetByIdMethod.getName());
+        Assert.assertEquals("/api/v3", getPetByIdMethod.getForwardedEndpoint());
+        Assert.assertEquals(HttpMethod.GET, getPetByIdMethod.getHttpMethod());
+        Assert.assertEquals(RestMethodStatus.MOCKED, getPetByIdMethod.getStatus());
+        Assert.assertEquals(RestResponseStrategy.SEQUENCE, getPetByIdMethod.getResponseStrategy());
+        Assert.assertEquals(Integer.valueOf(0), getPetByIdMethod.getCurrentResponseSequenceIndex());
+        Assert.assertEquals(0L, getPetByIdMethod.getNetworkDelay());
+        Assert.assertFalse(getPetByIdMethod.getSimulateNetworkDelay());
+        Assert.assertNull(getPetByIdMethod.getDefaultBody());
+        Assert.assertNull(getPetByIdMethod.getId());
+        Assert.assertNull(getPetByIdMethod.getResourceId());
+
+        if (generatedResponse) {
+            Assert.assertEquals(3, getPetByIdMethod.getMockResponses().size());
+
+            // 200
+            RestMockResponse response = getPetByIdMethod.getMockResponses().stream()
+                    .filter(method -> method.getName().equals("successful operation"))
+                    .findFirst()
+                    .get();
+
+            Assert.assertEquals("successful operation", response.getName());
+
+            Assert.assertEquals(Integer.valueOf(200), response.getHttpStatusCode());
+            Assert.assertEquals(RestMockResponseStatus.ENABLED, response.getStatus());
+            Assert.assertTrue(response.isUsingExpressions());
+            Assert.assertTrue(response.getContentEncodings().isEmpty());
+            Assert.assertNull(response.getId());
+            Assert.assertNull(response.getMethodId());
+
+
+            // 400
+            RestMockResponse invalidMockResponse = getPetByIdMethod.getMockResponses().stream()
+                    .filter(method -> method.getName().equals("Invalid ID supplied"))
+                    .findFirst()
+                    .get();
+
+            Assert.assertEquals("Invalid ID supplied", invalidMockResponse.getName());
+            Assert.assertNull(invalidMockResponse.getBody());
+
+            Assert.assertEquals(Integer.valueOf(400), invalidMockResponse.getHttpStatusCode());
+            Assert.assertEquals(RestMockResponseStatus.DISABLED, invalidMockResponse.getStatus());
+            Assert.assertTrue(invalidMockResponse.isUsingExpressions());
+            Assert.assertTrue(invalidMockResponse.getContentEncodings().isEmpty());
+            Assert.assertNull(invalidMockResponse.getId());
+            Assert.assertNull(invalidMockResponse.getMethodId());
+            Assert.assertEquals(0, invalidMockResponse.getHttpHeaders().size());
+
+            // 404
+            RestMockResponse notFoundResponse = getPetByIdMethod.getMockResponses().stream()
+                    .filter(method -> method.getName().equals("Pet not found"))
+                    .findFirst()
+                    .get();
+
+            Assert.assertEquals("Pet not found", notFoundResponse.getName());
+            Assert.assertNull(notFoundResponse.getBody());
+
+            Assert.assertEquals(Integer.valueOf(200), notFoundResponse.getHttpStatusCode());
+            Assert.assertEquals(RestMockResponseStatus.ENABLED, notFoundResponse.getStatus());
+            Assert.assertTrue(notFoundResponse.isUsingExpressions());
+            Assert.assertTrue(notFoundResponse.getContentEncodings().isEmpty());
+            Assert.assertNull(notFoundResponse.getId());
+            Assert.assertNull(notFoundResponse.getMethodId());
+            Assert.assertEquals(0, notFoundResponse.getHttpHeaders().size());
+        } else {
+            Assert.assertEquals(0, getPetByIdMethod.getMockResponses().size());
+        }
+
+
+        // /pet/{petId} (DELETE) - deletePet
+
+        RestMethod deletePetMethod = petWithParameterResource.getMethods().stream()
+                .filter(method -> method.getName().equals("deletePet"))
+                .findFirst()
+                .get();
+
+        Assert.assertNotNull(deletePetMethod);
+        Assert.assertEquals("deletePet", deletePetMethod.getName());
+        Assert.assertEquals("/api/v3", deletePetMethod.getForwardedEndpoint());
+        Assert.assertEquals(HttpMethod.DELETE, deletePetMethod.getHttpMethod());
+        Assert.assertEquals(RestMethodStatus.MOCKED, deletePetMethod.getStatus());
+        Assert.assertEquals(RestResponseStrategy.SEQUENCE, deletePetMethod.getResponseStrategy());
+        Assert.assertEquals(Integer.valueOf(0), deletePetMethod.getCurrentResponseSequenceIndex());
+        Assert.assertEquals(0L, deletePetMethod.getNetworkDelay());
+        Assert.assertFalse(deletePetMethod.getSimulateNetworkDelay());
+        Assert.assertNull(deletePetMethod.getDefaultBody());
+        Assert.assertNull(deletePetMethod.getId());
+        Assert.assertNull(deletePetMethod.getResourceId());
+
+        if (generatedResponse) {
+            Assert.assertEquals(1, deletePetMethod.getMockResponses().size());
+
+            // 400
+            RestMockResponse invalidMockResponse = deletePetMethod.getMockResponses().stream()
+                    .filter(method -> method.getName().equals("Auto-generated mocked response"))
+                    .findFirst()
+                    .get();
+
+            Assert.assertEquals("Auto-generated mocked response", invalidMockResponse.getName());
+            Assert.assertNull(invalidMockResponse.getBody());
+
+            Assert.assertEquals(Integer.valueOf(200), invalidMockResponse.getHttpStatusCode());
+            Assert.assertEquals(RestMockResponseStatus.ENABLED, invalidMockResponse.getStatus());
+            Assert.assertTrue(invalidMockResponse.isUsingExpressions());
+            Assert.assertTrue(invalidMockResponse.getContentEncodings().isEmpty());
+            Assert.assertNull(invalidMockResponse.getId());
+            Assert.assertNull(invalidMockResponse.getMethodId());
+            Assert.assertEquals(0, invalidMockResponse.getHttpHeaders().size());
+        } else {
+            Assert.assertEquals(0, deletePetMethod.getMockResponses().size());
+        }
+    }
+}

--- a/service/service-mock/service-mock-rest/src/test/resources/com/castlemock/service/mock/rest/project/converter/openapi/petstore.json
+++ b/service/service-mock/service-mock-rest/src/test/resources/com/castlemock/service/mock/rest/project/converter/openapi/petstore.json
@@ -1,0 +1,376 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Swagger Petstore - OpenAPI 3.0",
+    "description": "This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about\nSwagger at [http://swagger.io](http://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!\nYou can now help us improve the API whether it's by making changes to the definition itself or to the code.\nThat way, with time, we can improve the API in general, and expose some of the new features in OAS3.\n\nSome useful links:\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "email": "apiteam@swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "1.0.17"
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  },
+  "servers": [
+    {
+      "url": "/api/v3"
+    }
+  ],
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders",
+      "externalDocs": {
+        "description": "Find out more about our store",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "user",
+      "description": "Operations about user"
+    }
+  ],
+  "paths": {
+    "/pet": {
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Update an existing pet",
+        "description": "Update an existing pet by Id",
+        "operationId": "updatePet",
+        "requestBody": {
+          "description": "Update an existent pet in the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "405": {
+            "description": "Validation exception"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Add a new pet to the store",
+        "description": "Add a new pet to the store",
+        "operationId": "addPet",
+        "requestBody": {
+          "description": "Create a new pet in the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Find pet by ID",
+        "description": "Returns a single pet",
+        "operationId": "getPetById",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to return",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          },
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Deletes a pet",
+        "description": "",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "header",
+            "description": "",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "Pet id to delete",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid pet value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "required": [
+          "name",
+          "photoUrls"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "example": 10
+          },
+          "name": {
+            "type": "string",
+            "example": "doggie"
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "photoUrls": {
+            "type": "array",
+            "xml": {
+              "wrapped": true
+            },
+            "items": {
+              "type": "string",
+              "xml": {
+                "name": "photoUrl"
+              }
+            }
+          },
+          "tags": {
+            "type": "array",
+            "xml": {
+              "wrapped": true
+            },
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          },
+          "status": {
+            "type": "string",
+            "description": "pet status in the store",
+            "enum": [
+              "available",
+              "pending",
+              "sold"
+            ]
+          }
+        },
+        "xml": {
+          "name": "pet"
+        }
+      }
+    },
+    "requestBodies": {
+      "Pet": {
+        "description": "Pet object that needs to be added to the store",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Pet"
+            }
+          },
+          "application/xml": {
+            "schema": {
+              "$ref": "#/components/schemas/Pet"
+            }
+          }
+        }
+      },
+      "UserArray": {
+        "description": "List of user object",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://petstore3.swagger.io/oauth/authorize",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/service/service-mock/service-mock-rest/src/test/resources/com/castlemock/service/mock/rest/project/converter/openapi/petstore_malformed_openapi.json
+++ b/service/service-mock/service-mock-rest/src/test/resources/com/castlemock/service/mock/rest/project/converter/openapi/petstore_malformed_openapi.json
@@ -1,0 +1,373 @@
+{
+  "openapi": "3.0.2",
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  },
+  "servers": [
+    {
+      "url": "/api/v3"
+    }
+  ],
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders",
+      "externalDocs": {
+        "description": "Find out more about our store",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "user",
+      "description": "Operations about user"
+    }
+  ],
+  "paths": {
+    "/pet": {
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Update an existing pet",
+        "description": "Update an existing pet by Id",
+        "requestBody": {
+          "description": "Update an existent pet in the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "405": {
+            "description": "Validation exception"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "description": "Add a new pet to the store",
+        "operationId": "addPet",
+        "requestBody": {
+          "description": "Create a new pet in the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "headers": {
+              "X-Rate-Limit": {
+                "description": "calls per hour allowed by the user",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              },
+              "X-Expires-After": {
+                "description": "date in UTC when token expires",
+                "schema": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            },
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Find pet by ID",
+        "description": "Returns a single pet",
+        "operationId": "getPetById",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to return",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "A04": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          },
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Deletes a pet",
+        "description": "",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "header",
+            "description": "",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "Pet id to delete",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {},
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "required": [
+          "name",
+          "photoUrls"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "example": 10
+          },
+          "name": {
+            "type": "string",
+            "example": "doggie"
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "photoUrls": {
+            "type": "array",
+            "xml": {
+              "wrapped": true
+            },
+            "items": {
+              "type": "string",
+              "xml": {
+                "name": "photoUrl"
+              }
+            }
+          },
+          "tags": {
+            "type": "array",
+            "xml": {
+              "wrapped": true
+            },
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          },
+          "status": {
+            "type": "string",
+            "description": "pet status in the store",
+            "enum": [
+              "available",
+              "pending",
+              "sold"
+            ]
+          }
+        },
+        "xml": {
+          "name": "pet"
+        }
+      }
+    },
+    "requestBodies": {
+      "Pet": {
+        "description": "Pet object that needs to be added to the store",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Pet"
+            }
+          },
+          "application/xml": {
+            "schema": {
+              "$ref": "#/components/schemas/Pet"
+            }
+          }
+        }
+      },
+      "UserArray": {
+        "description": "List of user object",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://petstore3.swagger.io/oauth/authorize",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/web/web-frontend/src/components/project/rest/project/RestProject.js
+++ b/web/web-frontend/src/components/project/rest/project/RestProject.js
@@ -217,7 +217,8 @@ class RestProject extends PureComponent {
                                         </button>
                                         <div className="dropdown-menu" aria-labelledby="btnGroupDrop1">
                                             <button className="dropdown-item" data-toggle="modal" data-target="#uploadRAMLDefinitionModal">RAML</button>
-                                            <button className="dropdown-item" data-toggle="modal" data-target="#uploadSWAGGERDefinitionModal">Swagger</button>
+                                            <button className="dropdown-item" data-toggle="modal" data-target="#uploadSWAGGERDefinitionModal">Swagger V2</button>
+                                            <button className="dropdown-item" data-toggle="modal" data-target="#uploadOPENAPIDefinitionModal">OpenAPI V3</button>
                                             <button className="dropdown-item" data-toggle="modal" data-target="#uploadWADLDefinitionModal">WADL</button>
                                         </div>
                                     </div>
@@ -287,6 +288,7 @@ class RestProject extends PureComponent {
                 <UpdateProjectModal projectId={this.state.projectId} getProject={this.getProject} project={this.state.project}/>
                 <UpdateStatusModal projectId={this.state.projectId} getProject={this.getProject} selectedApplications={this.state.selectedApplications}/>
                 <UploadDefinitionModal projectId={this.state.projectId} getProject={this.getProject} definitionType={"SWAGGER"} />
+                <UploadDefinitionModal projectId={this.state.projectId} getProject={this.getProject} definitionType={"OPENAPI"} />
                 <UploadDefinitionModal projectId={this.state.projectId} getProject={this.getProject} definitionType={"RAML"} />
                 <UploadDefinitionModal projectId={this.state.projectId} getProject={this.getProject} definitionType={"WADL"} />
             </div>


### PR DESCRIPTION
[Summary]
- Add capability to read from OpenAPI v3 file and generate mock services
- Add capability to read from OpenAPI v3 link and generate mock services

[Description]
This pull request adds a new feature to Castlemock that allows users to import mocks directly from OpenAPI V3 specifications. This feature is particularly useful for users who are already using OpenAPI V3 to document their APIs and want to easily create mocks based on their existing documentation.
To use this feature, simply navigate to the import page and select the "OpenAPI V3" option. Then, provide the path to your OpenAPI V3 specification file and Castlemock will automatically generate mock services based on the provided specifications.

Please **note** that as of now, _this feature does not include fake data generation for success response types_, however it does import all the error and success response types from swagger with empty mock body. This is because it was complex to understand the existing fake data generator code and implement the new code for fake data generation functionality and it may take more time. Hence we may plan to address this issue in a future pull request.

This feature was **_tested extensively using various OpenAPI V3 specification files and URLs._**

**Fixes** https://github.com/castlemock/castlemock/issues/254

**Please let me know if you have any questions or comments on the code, I will take the necessary steps to correct it.**

[Jebish castlemock agreement.pdf](https://github.com/castlemock/castlemock/files/10942237/Jebish.castlemock.agreement.pdf)