### PR TITLE
Replace react-bootstrap-table2 with a custom Boostrap table implementation

### DIFF
--- a/web/web-frontend/package.json
+++ b/web/web-frontend/package.json
@@ -16,10 +16,6 @@
     "prop-types": "^15.8.0",
     "react": "18.2.0",
     "react-bootstrap": "^2.9.1",
-    "react-bootstrap-table-next": "^4.0.3",
-    "react-bootstrap-table2-filter": "^1.1.6",
-    "react-bootstrap-table2-paginator": "^2.0.4",
-    "react-bootstrap-table2-toolkit": "^2.1.3",
     "react-dom": "18.2.0",
     "react-router-dom": "^5.3.4"
   },

--- a/web/web-frontend/src/components/App.js
+++ b/web/web-frontend/src/components/App.js
@@ -20,12 +20,6 @@ import { createBrowserHistory } from 'history';
 import '../css/App.css';
 import 'bootstrap/dist/css/bootstrap.css';
 import 'bootstrap/dist/js/bootstrap.js';
-// import 'react-bootstrap-table-next/dist/react-bootstrap-table2.min.css';
-// import 'react-bootstrap-table-next/dist/react-bootstrap-table-next.min.js';
-// import 'react-bootstrap-table2-paginator/dist/react-bootstrap-table2-paginator.min.css';
-// import 'react-bootstrap-table2-paginator/dist/react-bootstrap-table2-paginator.min.js';
-// import 'react-bootstrap-table2-toolkit/dist/react-bootstrap-table2-toolkit.min.css';
-// import 'react-bootstrap-table2-toolkit/dist/react-bootstrap-table2-toolkit.min.js';
 import LoginContainer from './LoginContainer'
 import LogoutContainer from './LogoutContainer'
 import MainContainer from './MainContainer'

--- a/web/web-frontend/src/components/App.js
+++ b/web/web-frontend/src/components/App.js
@@ -20,12 +20,12 @@ import { createBrowserHistory } from 'history';
 import '../css/App.css';
 import 'bootstrap/dist/css/bootstrap.css';
 import 'bootstrap/dist/js/bootstrap.js';
-import 'react-bootstrap-table-next/dist/react-bootstrap-table2.min.css';
-import 'react-bootstrap-table-next/dist/react-bootstrap-table-next.min.js';
-import 'react-bootstrap-table2-paginator/dist/react-bootstrap-table2-paginator.min.css';
-import 'react-bootstrap-table2-paginator/dist/react-bootstrap-table2-paginator.min.js';
-import 'react-bootstrap-table2-toolkit/dist/react-bootstrap-table2-toolkit.min.css';
-import 'react-bootstrap-table2-toolkit/dist/react-bootstrap-table2-toolkit.min.js';
+// import 'react-bootstrap-table-next/dist/react-bootstrap-table2.min.css';
+// import 'react-bootstrap-table-next/dist/react-bootstrap-table-next.min.js';
+// import 'react-bootstrap-table2-paginator/dist/react-bootstrap-table2-paginator.min.css';
+// import 'react-bootstrap-table2-paginator/dist/react-bootstrap-table2-paginator.min.js';
+// import 'react-bootstrap-table2-toolkit/dist/react-bootstrap-table2-toolkit.min.css';
+// import 'react-bootstrap-table2-toolkit/dist/react-bootstrap-table2-toolkit.min.js';
 import LoginContainer from './LoginContainer'
 import LogoutContainer from './LogoutContainer'
 import MainContainer from './MainContainer'

--- a/web/web-frontend/src/components/event/overview/EventOverview.js
+++ b/web/web-frontend/src/components/event/overview/EventOverview.js
@@ -15,16 +15,13 @@
  */
 
 import React, {PureComponent} from 'react';
-// import BootstrapTable from 'react-bootstrap-table-next';
-// import ToolkitProvider, {Search} from 'react-bootstrap-table2-toolkit';
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from '../../utility/DataTable';
 import axios from "axios";
 import validateErrorResponse from "../../../utility/HttpResponseValidator";
 import {Link} from "react-router-dom";
 import {faTrash} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
-// const { SearchBar } = Search;
 
 class EventOverview extends PureComponent {
 
@@ -132,28 +129,16 @@ class EventOverview extends PureComponent {
                     </div>
                     <div className="panel panel-primary table-panel">
                         <div className="table-result">
-                            {/* <ToolkitProvider bootstrap4
-                                             columns={ this.columns}
-                                             data={ this.state.events }
-                                             keyField="id"
-                                             search>
-                                {
-                                    (props) => (
-                                        <div>
-                                            <div>
-                                                <SearchBar { ...props.searchProps } className={"table-filter-field"} />
-                                            </div>
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.state.events} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                selectRow={ this.selectRow }
-                                                                striped
-                                                                noDataIndication="No events has so far been recorded"
-                                                                pagination={ PaginationFactory() }/>
-                                            </div>
-                                        </div>
-                                    )}
-                            </ToolkitProvider> */}
+                            <DataTable
+                                columns={this.columns}
+                                data={this.state.events}
+                                keyField="id"
+                                search
+                                defaultSort={this.defaultSort}
+                                selectRow={this.selectRow}
+                                noDataIndication="No events has so far been recorded"
+                                pagination
+                            ></DataTable>
                         </div>
                     </div>
                 </section>

--- a/web/web-frontend/src/components/event/overview/EventOverview.js
+++ b/web/web-frontend/src/components/event/overview/EventOverview.js
@@ -15,16 +15,16 @@
  */
 
 import React, {PureComponent} from 'react';
-import BootstrapTable from 'react-bootstrap-table-next';
-import ToolkitProvider, {Search} from 'react-bootstrap-table2-toolkit';
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import BootstrapTable from 'react-bootstrap-table-next';
+// import ToolkitProvider, {Search} from 'react-bootstrap-table2-toolkit';
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import axios from "axios";
 import validateErrorResponse from "../../../utility/HttpResponseValidator";
 import {Link} from "react-router-dom";
 import {faTrash} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
-const { SearchBar } = Search;
+// const { SearchBar } = Search;
 
 class EventOverview extends PureComponent {
 
@@ -132,7 +132,7 @@ class EventOverview extends PureComponent {
                     </div>
                     <div className="panel panel-primary table-panel">
                         <div className="table-result">
-                            <ToolkitProvider bootstrap4
+                            {/* <ToolkitProvider bootstrap4
                                              columns={ this.columns}
                                              data={ this.state.events }
                                              keyField="id"
@@ -153,7 +153,7 @@ class EventOverview extends PureComponent {
                                             </div>
                                         </div>
                                     )}
-                            </ToolkitProvider>
+                            </ToolkitProvider> */}
                         </div>
                     </div>
                 </section>

--- a/web/web-frontend/src/components/event/rest/RestEvent.js
+++ b/web/web-frontend/src/components/event/rest/RestEvent.js
@@ -20,9 +20,7 @@ import validateErrorResponse from "../../../utility/HttpResponseValidator";
 import {Link} from "react-router-dom";
 import Tabs from "react-bootstrap/Tabs";
 import Tab from "react-bootstrap/Tab";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from '../../utility/DataTable';
 
 class RestEvent extends PureComponent {
 
@@ -139,23 +137,15 @@ class RestEvent extends PureComponent {
                                 }
                                 <h2>Headers</h2>
                                 <div className="table-result">
-                                    {/* <ToolkitProvider bootstrap4
-                                                     columns={ this.columns}
-                                                     data={this.state.event.request.httpHeaders}
-                                                     keyField="name"
-                                                     search>
-                                        {
-                                            (props) => (
-                                                <div>
-                                                    <BootstrapTable {...props.baseProps} bootstrap4
-                                                                    data={this.state.event.request.httpHeaders} columns={this.columns}
-                                                                    defaultSorted={this.defaultSort} keyField='name' hover
-                                                                    striped
-                                                                    noDataIndication="No headers"
-                                                                    pagination={ PaginationFactory() }/>
-                                                </div>
-                                            )}
-                                    </ToolkitProvider> */}
+                                    <DataTable
+                                        columns={this.columns}
+                                        data={this.state.event.request.httpHeaders}
+                                        keyField="name"
+                                        search
+                                        defaultSort={this.defaultSort}
+                                        noDataIndication="No headers"
+                                        pagination
+                                    ></DataTable>
                                 </div>
                             </Tab>
                             {this.state.event.response !== null &&
@@ -170,23 +160,15 @@ class RestEvent extends PureComponent {
                                     <div>
                                         <h2>Headers</h2>
                                         <div className="table-result">
-                                            {/* <ToolkitProvider bootstrap4
-                                                             columns={ this.columns}
-                                                             data={this.state.event.response.httpHeaders}
-                                                             keyField="name"
-                                                             search>
-                                                {
-                                                    (props) => (
-                                                        <div>
-                                                            <BootstrapTable {...props.baseProps} bootstrap4
-                                                                            data={this.state.event.response.httpHeaders} columns={this.columns}
-                                                                            defaultSorted={this.defaultSort} keyField='name' hover
-                                                                            striped
-                                                                            noDataIndication="No headers"
-                                                                            pagination={ PaginationFactory() }/>
-                                                        </div>
-                                                    )}
-                                            </ToolkitProvider> */}
+                                            <DataTable
+                                                columns={this.columns}
+                                                data={this.state.event.response.httpHeaders}
+                                                keyField="name"
+                                                search
+                                                defaultSort={this.defaultSort}
+                                                noDataIndication="No headers"
+                                                pagination
+                                            ></DataTable>
                                         </div>
                                     </div>
                                 </Tab>

--- a/web/web-frontend/src/components/event/rest/RestEvent.js
+++ b/web/web-frontend/src/components/event/rest/RestEvent.js
@@ -20,9 +20,9 @@ import validateErrorResponse from "../../../utility/HttpResponseValidator";
 import {Link} from "react-router-dom";
 import Tabs from "react-bootstrap/Tabs";
 import Tab from "react-bootstrap/Tab";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 
 class RestEvent extends PureComponent {
 
@@ -139,7 +139,7 @@ class RestEvent extends PureComponent {
                                 }
                                 <h2>Headers</h2>
                                 <div className="table-result">
-                                    <ToolkitProvider bootstrap4
+                                    {/* <ToolkitProvider bootstrap4
                                                      columns={ this.columns}
                                                      data={this.state.event.request.httpHeaders}
                                                      keyField="name"
@@ -155,7 +155,7 @@ class RestEvent extends PureComponent {
                                                                     pagination={ PaginationFactory() }/>
                                                 </div>
                                             )}
-                                    </ToolkitProvider>
+                                    </ToolkitProvider> */}
                                 </div>
                             </Tab>
                             {this.state.event.response !== null &&
@@ -170,7 +170,7 @@ class RestEvent extends PureComponent {
                                     <div>
                                         <h2>Headers</h2>
                                         <div className="table-result">
-                                            <ToolkitProvider bootstrap4
+                                            {/* <ToolkitProvider bootstrap4
                                                              columns={ this.columns}
                                                              data={this.state.event.response.httpHeaders}
                                                              keyField="name"
@@ -186,7 +186,7 @@ class RestEvent extends PureComponent {
                                                                             pagination={ PaginationFactory() }/>
                                                         </div>
                                                     )}
-                                            </ToolkitProvider>
+                                            </ToolkitProvider> */}
                                         </div>
                                     </div>
                                 </Tab>

--- a/web/web-frontend/src/components/event/soap/SoapEvent.js
+++ b/web/web-frontend/src/components/event/soap/SoapEvent.js
@@ -20,9 +20,7 @@ import validateErrorResponse from "../../../utility/HttpResponseValidator";
 import {Link} from "react-router-dom";
 import Tabs from "react-bootstrap/Tabs";
 import Tab from "react-bootstrap/Tab";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from '../../utility/DataTable';
 
 class SoapEvent extends PureComponent {
 
@@ -140,23 +138,15 @@ class SoapEvent extends PureComponent {
                                 }
                                 <h2>Headers</h2>
                                 <div className="table-result">
-                                    {/* <ToolkitProvider bootstrap4
-                                                     columns={ this.columns}
-                                                     data={this.state.event.request.httpHeaders}
-                                                     keyField="name"
-                                                     search>
-                                        {
-                                            (props) => (
-                                                <div>
-                                                    <BootstrapTable {...props.baseProps} bootstrap4
-                                                                    data={this.state.event.request.httpHeaders} columns={this.columns}
-                                                                    defaultSorted={this.defaultSort} keyField='name' hover
-                                                                    striped
-                                                                    noDataIndication="No headers"
-                                                                    pagination={ PaginationFactory() }/>
-                                                </div>
-                                            )}
-                                    </ToolkitProvider> */}
+                                    <DataTable
+                                        columns={this.columns}
+                                        data={this.state.event.request.httpHeaders}
+                                        keyField="name"
+                                        search
+                                        defaultSort={this.defaultSort}
+                                        noDataIndication="No headers"
+                                        pagination
+                                    ></DataTable>
                                 </div>
                             </Tab>
                             {this.state.event.response !== null &&
@@ -171,23 +161,15 @@ class SoapEvent extends PureComponent {
                                 <div>
                                     <h2>Headers</h2>
                                     <div className="table-result">
-                                        {/* <ToolkitProvider bootstrap4
-                                                         columns={ this.columns}
-                                                         data={this.state.event.response.httpHeaders}
-                                                         keyField="name"
-                                                         search>
-                                            {
-                                                (props) => (
-                                                    <div>
-                                                        <BootstrapTable {...props.baseProps} bootstrap4
-                                                                        data={this.state.event.response.httpHeaders} columns={this.columns}
-                                                                        defaultSorted={this.defaultSort} keyField='name' hover
-                                                                        striped
-                                                                        noDataIndication="No headers"
-                                                                        pagination={ PaginationFactory() }/>
-                                                    </div>
-                                                )}
-                                        </ToolkitProvider> */}
+                                        <DataTable
+                                            columns={this.columns}
+                                            data={this.state.event.response.httpHeaders}
+                                            keyField="name"
+                                            search
+                                            defaultSort={this.defaultSort}
+                                            noDataIndication="No headers"
+                                            pagination
+                                        ></DataTable>
                                     </div>
                                 </div>
                             </Tab>

--- a/web/web-frontend/src/components/event/soap/SoapEvent.js
+++ b/web/web-frontend/src/components/event/soap/SoapEvent.js
@@ -20,9 +20,9 @@ import validateErrorResponse from "../../../utility/HttpResponseValidator";
 import {Link} from "react-router-dom";
 import Tabs from "react-bootstrap/Tabs";
 import Tab from "react-bootstrap/Tab";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 
 class SoapEvent extends PureComponent {
 
@@ -140,7 +140,7 @@ class SoapEvent extends PureComponent {
                                 }
                                 <h2>Headers</h2>
                                 <div className="table-result">
-                                    <ToolkitProvider bootstrap4
+                                    {/* <ToolkitProvider bootstrap4
                                                      columns={ this.columns}
                                                      data={this.state.event.request.httpHeaders}
                                                      keyField="name"
@@ -156,7 +156,7 @@ class SoapEvent extends PureComponent {
                                                                     pagination={ PaginationFactory() }/>
                                                 </div>
                                             )}
-                                    </ToolkitProvider>
+                                    </ToolkitProvider> */}
                                 </div>
                             </Tab>
                             {this.state.event.response !== null &&
@@ -171,7 +171,7 @@ class SoapEvent extends PureComponent {
                                 <div>
                                     <h2>Headers</h2>
                                     <div className="table-result">
-                                        <ToolkitProvider bootstrap4
+                                        {/* <ToolkitProvider bootstrap4
                                                          columns={ this.columns}
                                                          data={this.state.event.response.httpHeaders}
                                                          keyField="name"
@@ -187,7 +187,7 @@ class SoapEvent extends PureComponent {
                                                                         pagination={ PaginationFactory() }/>
                                                     </div>
                                                 )}
-                                        </ToolkitProvider>
+                                        </ToolkitProvider> */}
                                     </div>
                                 </div>
                             </Tab>

--- a/web/web-frontend/src/components/project/overview/ProjectOverview.js
+++ b/web/web-frontend/src/components/project/overview/ProjectOverview.js
@@ -15,9 +15,9 @@
  */
 
 import React, {PureComponent} from 'react';
-import BootstrapTable from 'react-bootstrap-table-next';
-import ToolkitProvider, {Search} from 'react-bootstrap-table2-toolkit';
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import BootstrapTable from 'react-bootstrap-table-next';
+// import ToolkitProvider, {Search} from 'react-bootstrap-table2-toolkit';
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import axios from "axios";
 import {Link} from "react-router-dom";
 import Badge from 'react-bootstrap/Badge'
@@ -28,7 +28,7 @@ import {isOnlyReader} from "../../../utility/AuthorizeUtility";
 import preventEnterEvent from "../../../utility/KeyboardUtility";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
-const { SearchBar } = Search;
+// const { SearchBar } = Search;
 
 const SELECT = true;
 const DESELECT = false;
@@ -314,7 +314,7 @@ class ProjectOverview extends PureComponent {
                     </div>
                     <div className="panel panel-primary table-panel">
                         <div className="table-result">
-                            <ToolkitProvider bootstrap4
+                            {/* <ToolkitProvider bootstrap4
                                              columns={ this.columns}
                                              data={ this.state.projects }
                                              keyField="id"
@@ -335,7 +335,7 @@ class ProjectOverview extends PureComponent {
                                             </div>
                                             </div>
                                     )}
-                            </ToolkitProvider>
+                            </ToolkitProvider> */}
                         </div>
                         <div className="table-result">
                             <div className="panel-buttons">
@@ -441,7 +441,7 @@ class ProjectOverview extends PureComponent {
                             <div className="modal-body">
                                 <p>Do you want delete the following projects?</p>
                                 <div className="table-result">
-                                    <ToolkitProvider bootstrap4
+                                    {/* <ToolkitProvider bootstrap4
                                                      columns={ this.deleteColumns}
                                                      data={ this.state.selectedProjects }
                                                      keyField="id">
@@ -454,7 +454,7 @@ class ProjectOverview extends PureComponent {
                                                                     pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                                 </div>
                                             )}
-                                    </ToolkitProvider>
+                                    </ToolkitProvider> */}
                                 </div>
                             </div>
                             <div className="modal-footer">

--- a/web/web-frontend/src/components/project/overview/ProjectOverview.js
+++ b/web/web-frontend/src/components/project/overview/ProjectOverview.js
@@ -322,6 +322,7 @@ class ProjectOverview extends PureComponent {
                                 search
                                 noDataIndication="Click on 'New project' button to create a new project"
                                 selectRow={this.selectRow}
+                                defaultSort={this.defaultSort}
                             ></DataTable>
                             {/* <ToolkitProvider bootstrap4
                                              columns={ this.columns}

--- a/web/web-frontend/src/components/project/overview/ProjectOverview.js
+++ b/web/web-frontend/src/components/project/overview/ProjectOverview.js
@@ -319,10 +319,11 @@ class ProjectOverview extends PureComponent {
                                 columns={this.columns}
                                 data={this.state.projects}
                                 keyField="id"
-                                search
                                 noDataIndication="Click on 'New project' button to create a new project"
-                                selectRow={this.selectRow}
                                 defaultSort={this.defaultSort}
+                                selectRow={this.selectRow}
+                                search
+                                pagination
                             ></DataTable>
                             {/* <ToolkitProvider bootstrap4
                                              columns={ this.columns}

--- a/web/web-frontend/src/components/project/overview/ProjectOverview.js
+++ b/web/web-frontend/src/components/project/overview/ProjectOverview.js
@@ -18,6 +18,7 @@ import React, {PureComponent} from 'react';
 // import BootstrapTable from 'react-bootstrap-table-next';
 // import ToolkitProvider, {Search} from 'react-bootstrap-table2-toolkit';
 // import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from '../../utility/DataTable';
 import axios from "axios";
 import {Link} from "react-router-dom";
 import Badge from 'react-bootstrap/Badge'
@@ -314,6 +315,14 @@ class ProjectOverview extends PureComponent {
                     </div>
                     <div className="panel panel-primary table-panel">
                         <div className="table-result">
+                            <DataTable
+                                columns={this.columns}
+                                data={this.state.projects}
+                                keyField="id"
+                                search
+                                noDataIndication="Click on 'New project' button to create a new project"
+                                selectRow={this.selectRow}
+                            ></DataTable>
                             {/* <ToolkitProvider bootstrap4
                                              columns={ this.columns}
                                              data={ this.state.projects }
@@ -441,6 +450,11 @@ class ProjectOverview extends PureComponent {
                             <div className="modal-body">
                                 <p>Do you want delete the following projects?</p>
                                 <div className="table-result">
+                                <DataTable
+                                    columns={this.deleteColumns}
+                                    data={this.state.selectedProjects}
+                                    keyField="id"
+                                ></DataTable>
                                     {/* <ToolkitProvider bootstrap4
                                                      columns={ this.deleteColumns}
                                                      data={ this.state.selectedProjects }

--- a/web/web-frontend/src/components/project/overview/ProjectOverview.js
+++ b/web/web-frontend/src/components/project/overview/ProjectOverview.js
@@ -53,7 +53,7 @@ class ProjectOverview extends PureComponent {
             hidden: true
         }, {
             dataField: 'type',
-            width: "20",
+            width: 20,
             maxWidth: 20,
             text: 'Type',
             sort: true,
@@ -178,7 +178,7 @@ class ProjectOverview extends PureComponent {
     }
 
     typeHeaderStyle() {
-        return { 'whiteSpace': 'nowrap', width: '150px' };
+        return { 'whiteSpace': 'nowrap', width: '20px' };
     }
 
     onRowSelect(value, mode) {

--- a/web/web-frontend/src/components/project/overview/ProjectOverview.js
+++ b/web/web-frontend/src/components/project/overview/ProjectOverview.js
@@ -15,9 +15,6 @@
  */
 
 import React, {PureComponent} from 'react';
-// import BootstrapTable from 'react-bootstrap-table-next';
-// import ToolkitProvider, {Search} from 'react-bootstrap-table2-toolkit';
-// import PaginationFactory from "react-bootstrap-table2-paginator";
 import DataTable from '../../utility/DataTable';
 import axios from "axios";
 import {Link} from "react-router-dom";
@@ -28,8 +25,6 @@ import AuthenticationContext from "../../../context/AuthenticationContext";
 import {isOnlyReader} from "../../../utility/AuthorizeUtility";
 import preventEnterEvent from "../../../utility/KeyboardUtility";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-
-// const { SearchBar } = Search;
 
 const SELECT = true;
 const DESELECT = false;
@@ -319,34 +314,12 @@ class ProjectOverview extends PureComponent {
                                 columns={this.columns}
                                 data={this.state.projects}
                                 keyField="id"
-                                noDataIndication="Click on 'New project' button to create a new project"
+                                search
                                 defaultSort={this.defaultSort}
                                 selectRow={this.selectRow}
-                                search
+                                noDataIndication="Click on 'New project' button to create a new project"
                                 pagination
                             ></DataTable>
-                            {/* <ToolkitProvider bootstrap4
-                                             columns={ this.columns}
-                                             data={ this.state.projects }
-                                             keyField="id"
-                                             search>
-                                {
-                                    (props) => (
-                                        <div>
-                                            <div>
-                                                <SearchBar { ...props.searchProps } className={"table-filter-field"} />
-                                            </div>
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.state.projects} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                selectRow={ this.selectRow }
-                                                                striped
-                                                                noDataIndication="Click on 'New project' button to create a new project"
-                                                                pagination={ PaginationFactory() }/>
-                                            </div>
-                                            </div>
-                                    )}
-                            </ToolkitProvider> */}
                         </div>
                         <div className="table-result">
                             <div className="panel-buttons">
@@ -452,25 +425,13 @@ class ProjectOverview extends PureComponent {
                             <div className="modal-body">
                                 <p>Do you want delete the following projects?</p>
                                 <div className="table-result">
-                                <DataTable
-                                    columns={this.deleteColumns}
-                                    data={this.state.selectedProjects}
-                                    keyField="id"
-                                ></DataTable>
-                                    {/* <ToolkitProvider bootstrap4
-                                                     columns={ this.deleteColumns}
-                                                     data={ this.state.selectedProjects }
-                                                     keyField="id">
-                                        {
-                                            (props) => (
-                                                <div>
-                                                    <BootstrapTable { ...props.baseProps } bootstrap4 data={this.state.selectedProjects} columns={this.deleteColumns}
-                                                                    defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                    striped
-                                                                    pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                                </div>
-                                            )}
-                                    </ToolkitProvider> */}
+                                    <DataTable
+                                        columns={this.deleteColumns}
+                                        data={this.state.selectedProjects}
+                                        keyField="id"
+                                        defaultSort={this.defaultSort}
+                                        pagination={{ hideSizePerPage: true }}
+                                    ></DataTable>
                                 </div>
                             </div>
                             <div className="modal-footer">

--- a/web/web-frontend/src/components/project/rest/application/RestApplication.js
+++ b/web/web-frontend/src/components/project/rest/application/RestApplication.js
@@ -17,9 +17,7 @@
 import React, {PureComponent} from 'react';
 import {Link} from "react-router-dom";
 import axios from "axios";
-// import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from '../../../utility/DataTable';
 import validateErrorResponse from "../../../../utility/HttpResponseValidator";
 import DeleteApplicationModal from "./modal/DeleteApplicationModal";
 import DeleteResourcesModal from "./modal/DeleteResourcesModal";
@@ -32,7 +30,6 @@ import AuthenticationContext from "../../../../context/AuthenticationContext";
 import {faEdit, faTrash, faFile, faCodeBranch} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
-// const { SearchBar } = Search;
 const SELECT = true;
 const DESELECT = false;
 
@@ -210,25 +207,16 @@ class RestApplication extends PureComponent {
                             <h3 className="panel-title">Resources</h3>
                         </div>
                         <div className="table-result">
-                            {/* <ToolkitProvider bootstrap4
-                                             columns={ this.columns}
-                                             data={this.state.application.resources}
-                                             keyField="id"
-                                             search>
-                                {
-                                    (props) => (
-                                        <div>
-                                            <div>
-                                                <SearchBar {...props.searchProps} className={"table-filter-field"}/>
-                                            </div>
-                                            <BootstrapTable {...props.baseProps} bootstrap4
-                                                            data={this.state.application.resources} columns={this.columns}
-                                                            defaultSorted={this.defaultSort} keyField='id' hover
-                                                            selectRow={this.selectRow}
-                                                            pagination={ PaginationFactory() }/>
-                                        </div>
-                                    )}
-                            </ToolkitProvider> */}
+                            <DataTable
+                                columns={this.columns}
+                                data={this.state.application.resources}
+                                keyField="id"
+                                search
+                                defaultSort={this.defaultSort}
+                                noDataIndication="No resources"
+                                selectRow={this.selectRow}
+                                pagination
+                            ></DataTable>
                             <AuthenticationContext.Consumer>
                                 {context => (
                                     <div className="panel-buttons">

--- a/web/web-frontend/src/components/project/rest/application/RestApplication.js
+++ b/web/web-frontend/src/components/project/rest/application/RestApplication.js
@@ -17,9 +17,9 @@
 import React, {PureComponent} from 'react';
 import {Link} from "react-router-dom";
 import axios from "axios";
-import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import validateErrorResponse from "../../../../utility/HttpResponseValidator";
 import DeleteApplicationModal from "./modal/DeleteApplicationModal";
 import DeleteResourcesModal from "./modal/DeleteResourcesModal";
@@ -32,7 +32,7 @@ import AuthenticationContext from "../../../../context/AuthenticationContext";
 import {faEdit, faTrash, faFile, faCodeBranch} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
-const { SearchBar } = Search;
+// const { SearchBar } = Search;
 const SELECT = true;
 const DESELECT = false;
 
@@ -210,7 +210,7 @@ class RestApplication extends PureComponent {
                             <h3 className="panel-title">Resources</h3>
                         </div>
                         <div className="table-result">
-                            <ToolkitProvider bootstrap4
+                            {/* <ToolkitProvider bootstrap4
                                              columns={ this.columns}
                                              data={this.state.application.resources}
                                              keyField="id"
@@ -228,7 +228,7 @@ class RestApplication extends PureComponent {
                                                             pagination={ PaginationFactory() }/>
                                         </div>
                                     )}
-                            </ToolkitProvider>
+                            </ToolkitProvider> */}
                             <AuthenticationContext.Consumer>
                                 {context => (
                                     <div className="panel-buttons">

--- a/web/web-frontend/src/components/project/rest/application/modal/DeleteResourcesModal.js
+++ b/web/web-frontend/src/components/project/rest/application/modal/DeleteResourcesModal.js
@@ -17,9 +17,9 @@
 import React, {PureComponent} from "react";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import {faTrash} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
@@ -73,7 +73,7 @@ class DeleteResourcesModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want delete the following resources?</p>
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.columns}
                                                  data={ this.props.selectedResources }
                                                  keyField="id">
@@ -86,7 +86,7 @@ class DeleteResourcesModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                         </div>
                         <div className="modal-footer">

--- a/web/web-frontend/src/components/project/rest/application/modal/DeleteResourcesModal.js
+++ b/web/web-frontend/src/components/project/rest/application/modal/DeleteResourcesModal.js
@@ -17,9 +17,7 @@
 import React, {PureComponent} from "react";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../../../utility/DataTable";
 import {faTrash} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
@@ -73,20 +71,12 @@ class DeleteResourcesModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want delete the following resources?</p>
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.columns}
-                                                 data={ this.props.selectedResources }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedResources} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.columns}
+                                    data={this.props.selectedResources}
+                                    keyField="id"
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                         </div>
                         <div className="modal-footer">

--- a/web/web-frontend/src/components/project/rest/application/modal/UpdateEndpointModal.js
+++ b/web/web-frontend/src/components/project/rest/application/modal/UpdateEndpointModal.js
@@ -15,9 +15,9 @@
  */
 
 import React, {PureComponent} from "react";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import {faCheckCircle} from "@fortawesome/free-solid-svg-icons";
@@ -87,7 +87,7 @@ class UpdateEndpointModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the endpoint for the following resources?</p>
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.columns}
                                                  data={ this.props.selectedResources }
                                                  keyField="id">
@@ -100,7 +100,7 @@ class UpdateEndpointModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Endpoint</label>

--- a/web/web-frontend/src/components/project/rest/application/modal/UpdateEndpointModal.js
+++ b/web/web-frontend/src/components/project/rest/application/modal/UpdateEndpointModal.js
@@ -15,9 +15,7 @@
  */
 
 import React, {PureComponent} from "react";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../../../utility/DataTable";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import {faCheckCircle} from "@fortawesome/free-solid-svg-icons";
@@ -87,20 +85,13 @@ class UpdateEndpointModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the endpoint for the following resources?</p>
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.columns}
-                                                 data={ this.props.selectedResources }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedResources} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.columns}
+                                    data={this.props.selectedResources}
+                                    keyField="id"
+                                    defaultSort={this.defaultSort}
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Endpoint</label>

--- a/web/web-frontend/src/components/project/rest/application/modal/UpdateStatusModal.js
+++ b/web/web-frontend/src/components/project/rest/application/modal/UpdateStatusModal.js
@@ -15,9 +15,9 @@
  */
 
 import React, {PureComponent} from "react";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import {methodStatusFormatter} from "../../utility/RestFormatter";
@@ -88,7 +88,7 @@ class UpdateStatusModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the status for the following resources?</p>
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.columns}
                                                  data={ this.props.selectedResources }
                                                  keyField="id">
@@ -101,7 +101,7 @@ class UpdateStatusModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Status</label>

--- a/web/web-frontend/src/components/project/rest/application/modal/UpdateStatusModal.js
+++ b/web/web-frontend/src/components/project/rest/application/modal/UpdateStatusModal.js
@@ -15,9 +15,7 @@
  */
 
 import React, {PureComponent} from "react";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../../../utility/DataTable";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import {methodStatusFormatter} from "../../utility/RestFormatter";
@@ -88,20 +86,13 @@ class UpdateStatusModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the status for the following resources?</p>
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.columns}
-                                                 data={ this.props.selectedResources }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedResources} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.columns}
+                                    data={this.props.selectedResources}
+                                    keyField="id"
+                                    defaultSort={this.defaultSort}
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Status</label>

--- a/web/web-frontend/src/components/project/rest/method/RestMethod.js
+++ b/web/web-frontend/src/components/project/rest/method/RestMethod.js
@@ -17,9 +17,7 @@
 import React, {PureComponent} from 'react';
 import {Link} from "react-router-dom";
 import axios from "axios";
-// import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from '../../../utility/DataTable';
 import validateErrorResponse from "../../../../utility/HttpResponseValidator";
 import DeleteMethodModal from "./modal/DeleteMethodModal";
 import DeleteMockResponsesModal from "./modal/DeleteMockResponsesModal";
@@ -34,7 +32,6 @@ import ContextContext from "../../../../context/ContextContext";
 import {faEdit, faFile, faTrash, faCopy} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
-// const { SearchBar } = Search;
 const SELECT = true;
 const DESELECT = false;
 
@@ -240,26 +237,16 @@ class RestMethod extends PureComponent {
                             <h3 className="panel-title">Mock responses</h3>
                         </div>
                         <div className="table-result">
-                            {/* <ToolkitProvider bootstrap4
-                                             columns={ this.columns}
-                                             data={this.state.method.mockResponses}
-                                             keyField="id"
-                                             search>
-                                {
-                                    (props) => (
-                                        <div>
-                                            <div>
-                                                <SearchBar {...props.searchProps} className={"table-filter-field"}/>
-                                            </div>
-                                            <BootstrapTable {...props.baseProps} bootstrap4
-                                                            data={this.state.method.mockResponses} columns={this.columns}
-                                                            defaultSorted={this.defaultSort} keyField='id' hover
-                                                            selectRow={this.selectRow}
-                                                            noDataIndication="No mocked responses"
-                                                            pagination={ PaginationFactory() }/>
-                                        </div>
-                                    )}
-                            </ToolkitProvider> */}
+                            <DataTable
+                                columns={this.columns}
+                                data={this.state.method.mockResponses}
+                                keyField="id"
+                                search
+                                defaultSort={this.defaultSort}
+                                selectRow={this.selectRow}
+                                noDataIndication="No mocked responses"
+                                pagination
+                            ></DataTable>
                             <AuthenticationContext.Consumer>
                                 {context => (
                                     <div className="panel-buttons">

--- a/web/web-frontend/src/components/project/rest/method/RestMethod.js
+++ b/web/web-frontend/src/components/project/rest/method/RestMethod.js
@@ -17,9 +17,9 @@
 import React, {PureComponent} from 'react';
 import {Link} from "react-router-dom";
 import axios from "axios";
-import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import validateErrorResponse from "../../../../utility/HttpResponseValidator";
 import DeleteMethodModal from "./modal/DeleteMethodModal";
 import DeleteMockResponsesModal from "./modal/DeleteMockResponsesModal";
@@ -34,7 +34,7 @@ import ContextContext from "../../../../context/ContextContext";
 import {faEdit, faFile, faTrash, faCopy} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
-const { SearchBar } = Search;
+// const { SearchBar } = Search;
 const SELECT = true;
 const DESELECT = false;
 
@@ -240,7 +240,7 @@ class RestMethod extends PureComponent {
                             <h3 className="panel-title">Mock responses</h3>
                         </div>
                         <div className="table-result">
-                            <ToolkitProvider bootstrap4
+                            {/* <ToolkitProvider bootstrap4
                                              columns={ this.columns}
                                              data={this.state.method.mockResponses}
                                              keyField="id"
@@ -259,7 +259,7 @@ class RestMethod extends PureComponent {
                                                             pagination={ PaginationFactory() }/>
                                         </div>
                                     )}
-                            </ToolkitProvider>
+                            </ToolkitProvider> */}
                             <AuthenticationContext.Consumer>
                                 {context => (
                                     <div className="panel-buttons">

--- a/web/web-frontend/src/components/project/rest/method/modal/DeleteMockResponsesModal.js
+++ b/web/web-frontend/src/components/project/rest/method/modal/DeleteMockResponsesModal.js
@@ -17,9 +17,7 @@
 import React, {PureComponent} from "react";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../../../utility/DataTable";
 import {faTrash} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
@@ -74,20 +72,13 @@ class DeleteMockResponsesModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want delete the following responses?</p>
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.columns}
-                                                 data={ this.props.selectedMockResponses }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedMockResponses} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.columns}
+                                    data={this.props.selectedMockResponses}
+                                    keyField="id"
+                                    defaultSort={this.defaultSort}
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                         </div>
                         <div className="modal-footer">

--- a/web/web-frontend/src/components/project/rest/method/modal/DeleteMockResponsesModal.js
+++ b/web/web-frontend/src/components/project/rest/method/modal/DeleteMockResponsesModal.js
@@ -17,9 +17,9 @@
 import React, {PureComponent} from "react";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import {faTrash} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
@@ -74,7 +74,7 @@ class DeleteMockResponsesModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want delete the following responses?</p>
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.columns}
                                                  data={ this.props.selectedMockResponses }
                                                  keyField="id">
@@ -87,7 +87,7 @@ class DeleteMockResponsesModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                         </div>
                         <div className="modal-footer">

--- a/web/web-frontend/src/components/project/rest/method/modal/DuplicateMockResponsesModal.js
+++ b/web/web-frontend/src/components/project/rest/method/modal/DuplicateMockResponsesModal.js
@@ -17,9 +17,7 @@
 import React, {PureComponent} from "react";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../../../utility/DataTable";
 import {faCheckCircle} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
@@ -80,20 +78,13 @@ class DuplicateMockResponsesModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want duplicate the following responses?</p>
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.columns}
-                                                 data={ this.props.selectedMockResponses }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedMockResponses} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.columns}
+                                    data={this.props.selectedMockResponses}
+                                    keyField="id"
+                                    defaultSort={this.defaultSort}
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                         </div>
                         <div className="modal-footer">

--- a/web/web-frontend/src/components/project/rest/method/modal/DuplicateMockResponsesModal.js
+++ b/web/web-frontend/src/components/project/rest/method/modal/DuplicateMockResponsesModal.js
@@ -17,9 +17,9 @@
 import React, {PureComponent} from "react";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import {faCheckCircle} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
@@ -80,7 +80,7 @@ class DuplicateMockResponsesModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want duplicate the following responses?</p>
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.columns}
                                                  data={ this.props.selectedMockResponses }
                                                  keyField="id">
@@ -93,7 +93,7 @@ class DuplicateMockResponsesModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                         </div>
                         <div className="modal-footer">

--- a/web/web-frontend/src/components/project/rest/method/modal/UpdateStatusModal.js
+++ b/web/web-frontend/src/components/project/rest/method/modal/UpdateStatusModal.js
@@ -15,9 +15,7 @@
  */
 
 import React, {PureComponent} from "react";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../../../utility/DataTable";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import {mockResponseStatusFormatter} from "../../utility/RestFormatter";
@@ -91,20 +89,13 @@ class UpdateStatusModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the status for the following methods?</p>
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.columns}
-                                                 data={ this.props.selectedMockResponses }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedMockResponses} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.columns}
+                                    data={this.props.selectedMockResponses}
+                                    keyField="id"
+                                    defaultSort={this.defaultSort}
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Status</label>

--- a/web/web-frontend/src/components/project/rest/method/modal/UpdateStatusModal.js
+++ b/web/web-frontend/src/components/project/rest/method/modal/UpdateStatusModal.js
@@ -15,9 +15,9 @@
  */
 
 import React, {PureComponent} from "react";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import {mockResponseStatusFormatter} from "../../utility/RestFormatter";
@@ -91,7 +91,7 @@ class UpdateStatusModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the status for the following methods?</p>
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.columns}
                                                  data={ this.props.selectedMockResponses }
                                                  keyField="id">
@@ -104,7 +104,7 @@ class UpdateStatusModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Status</label>

--- a/web/web-frontend/src/components/project/rest/project/RestProject.js
+++ b/web/web-frontend/src/components/project/rest/project/RestProject.js
@@ -246,7 +246,7 @@ class RestProject extends PureComponent {
                                 search
                                 defaultSort={this.defaultSort}
                                 selectRow={this.selectRow}
-                                noDataIndication="Click on the 'Upload' to upload a REST API definition"
+                                noDataIndication="Click on the 'Upload' button to upload a REST API definition"
                                 pagination
                             ></DataTable>
                             <AuthenticationContext.Consumer>

--- a/web/web-frontend/src/components/project/rest/project/RestProject.js
+++ b/web/web-frontend/src/components/project/rest/project/RestProject.js
@@ -17,9 +17,9 @@
 import React, {PureComponent} from 'react';
 import {Link} from "react-router-dom";
 import axios from "axios";
-import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import validateErrorResponse from "../../../../utility/HttpResponseValidator";
 import Badge from "react-bootstrap/Badge";
 import UpdateStatusModal from "./modal/UpdateStatusModal";
@@ -34,7 +34,7 @@ import AuthenticationContext from "../../../../context/AuthenticationContext";
 import {faCloudDownloadAlt, faFile, faTrash, faCloudUploadAlt, faEdit, faCodeBranch} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
-const { SearchBar } = Search;
+// const { SearchBar } = Search;
 const SELECT = true;
 const DESELECT = false;
 
@@ -242,7 +242,7 @@ class RestProject extends PureComponent {
                             <h3 className="panel-title">Applications</h3>
                         </div>
                         <div className="table-result">
-                            <ToolkitProvider bootstrap4
+                            {/* <ToolkitProvider bootstrap4
                                              columns={ this.columns}
                                              data={this.state.project.applications}
                                              keyField="id"
@@ -261,7 +261,7 @@ class RestProject extends PureComponent {
                                                             pagination={ PaginationFactory() }/>
                                         </div>
                                     )}
-                            </ToolkitProvider>
+                            </ToolkitProvider> */}
                             <AuthenticationContext.Consumer>
                                 {context => (
                                     <div className="panel-buttons">

--- a/web/web-frontend/src/components/project/rest/project/RestProject.js
+++ b/web/web-frontend/src/components/project/rest/project/RestProject.js
@@ -17,9 +17,7 @@
 import React, {PureComponent} from 'react';
 import {Link} from "react-router-dom";
 import axios from "axios";
-// import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from '../../../utility/DataTable';
 import validateErrorResponse from "../../../../utility/HttpResponseValidator";
 import Badge from "react-bootstrap/Badge";
 import UpdateStatusModal from "./modal/UpdateStatusModal";
@@ -34,7 +32,6 @@ import AuthenticationContext from "../../../../context/AuthenticationContext";
 import {faCloudDownloadAlt, faFile, faTrash, faCloudUploadAlt, faEdit, faCodeBranch} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
-// const { SearchBar } = Search;
 const SELECT = true;
 const DESELECT = false;
 
@@ -242,26 +239,16 @@ class RestProject extends PureComponent {
                             <h3 className="panel-title">Applications</h3>
                         </div>
                         <div className="table-result">
-                            {/* <ToolkitProvider bootstrap4
-                                             columns={ this.columns}
-                                             data={this.state.project.applications}
-                                             keyField="id"
-                                             search>
-                                {
-                                    (props) => (
-                                        <div>
-                                            <div>
-                                                <SearchBar {...props.searchProps} className={"table-filter-field"}/>
-                                            </div>
-                                            <BootstrapTable {...props.baseProps} bootstrap4
-                                                            data={this.state.project.applications} columns={this.columns}
-                                                            defaultSorted={this.defaultSort} keyField='id' hover
-                                                            selectRow={this.selectRow}
-                                                            noDataIndication="Click on the 'Upload' to upload a REST API definition"
-                                                            pagination={ PaginationFactory() }/>
-                                        </div>
-                                    )}
-                            </ToolkitProvider> */}
+                            <DataTable
+                                columns={this.columns}
+                                data={this.state.project.applications}
+                                keyField="id"
+                                search
+                                defaultSort={this.defaultSort}
+                                selectRow={this.selectRow}
+                                noDataIndication="Click on the 'Upload' to upload a REST API definition"
+                                pagination
+                            ></DataTable>
                             <AuthenticationContext.Consumer>
                                 {context => (
                                     <div className="panel-buttons">

--- a/web/web-frontend/src/components/project/rest/project/modal/DeleteApplicationsModal.js
+++ b/web/web-frontend/src/components/project/rest/project/modal/DeleteApplicationsModal.js
@@ -17,9 +17,9 @@
 import React, {PureComponent} from "react";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import {faTrash} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
@@ -75,7 +75,7 @@ class DeleteApplicationsModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want delete the following applications?</p>
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.columns}
                                                  data={ this.props.selectedApplications }
                                                  keyField="id">
@@ -88,7 +88,7 @@ class DeleteApplicationsModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                         </div>
                         <div className="modal-footer">

--- a/web/web-frontend/src/components/project/rest/project/modal/DeleteApplicationsModal.js
+++ b/web/web-frontend/src/components/project/rest/project/modal/DeleteApplicationsModal.js
@@ -17,9 +17,7 @@
 import React, {PureComponent} from "react";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../../../utility/DataTable";
 import {faTrash} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
@@ -75,20 +73,13 @@ class DeleteApplicationsModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want delete the following applications?</p>
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.columns}
-                                                 data={ this.props.selectedApplications }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedApplications} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.columns}
+                                    data={this.props.selectedApplications}
+                                    keyField="id"
+                                    defaultSort={this.defaultSort}
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                         </div>
                         <div className="modal-footer">

--- a/web/web-frontend/src/components/project/rest/project/modal/UpdateEndpointModal.js
+++ b/web/web-frontend/src/components/project/rest/project/modal/UpdateEndpointModal.js
@@ -15,9 +15,9 @@
  */
 
 import React, {PureComponent} from "react";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import {faCheckCircle} from "@fortawesome/free-solid-svg-icons";
@@ -86,7 +86,7 @@ class UpdateEndpointModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the endpoint for the following applications?</p>
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.columns}
                                                  data={ this.props.selectedApplications }
                                                  keyField="id">
@@ -99,7 +99,7 @@ class UpdateEndpointModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Endpoint</label>

--- a/web/web-frontend/src/components/project/rest/project/modal/UpdateEndpointModal.js
+++ b/web/web-frontend/src/components/project/rest/project/modal/UpdateEndpointModal.js
@@ -15,9 +15,7 @@
  */
 
 import React, {PureComponent} from "react";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../../../utility/DataTable";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import {faCheckCircle} from "@fortawesome/free-solid-svg-icons";
@@ -86,20 +84,13 @@ class UpdateEndpointModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the endpoint for the following applications?</p>
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.columns}
-                                                 data={ this.props.selectedApplications }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedApplications} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.columns}
+                                    data={this.props.selectedApplications}
+                                    keyField="id"
+                                    defaultSort={this.defaultSort}
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Endpoint</label>

--- a/web/web-frontend/src/components/project/rest/project/modal/UpdateStatusModal.js
+++ b/web/web-frontend/src/components/project/rest/project/modal/UpdateStatusModal.js
@@ -15,9 +15,9 @@
  */
 
 import React, {PureComponent} from "react";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import {methodStatusFormatter} from "../../utility/RestFormatter";
@@ -87,7 +87,7 @@ class UpdateStatusModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the status for the following applications?</p>
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.columns}
                                                  data={ this.props.selectedApplications }
                                                  keyField="id">
@@ -100,7 +100,7 @@ class UpdateStatusModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Status</label>

--- a/web/web-frontend/src/components/project/rest/project/modal/UpdateStatusModal.js
+++ b/web/web-frontend/src/components/project/rest/project/modal/UpdateStatusModal.js
@@ -15,9 +15,7 @@
  */
 
 import React, {PureComponent} from "react";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../../../utility/DataTable";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import {methodStatusFormatter} from "../../utility/RestFormatter";
@@ -87,20 +85,13 @@ class UpdateStatusModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the status for the following applications?</p>
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.columns}
-                                                 data={ this.props.selectedApplications }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedApplications} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.columns}
+                                    data={this.props.selectedApplications}
+                                    keyField="id"
+                                    defaultSort={this.defaultSort}
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Status</label>

--- a/web/web-frontend/src/components/project/rest/resource/RestResource.js
+++ b/web/web-frontend/src/components/project/rest/resource/RestResource.js
@@ -17,9 +17,9 @@
 import React, {PureComponent} from 'react';
 import {Link} from "react-router-dom";
 import axios from "axios";
-import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import validateErrorResponse from "../../../../utility/HttpResponseValidator";
 import DeleteMethodsModal from "./modal/DeleteMethodsModal";
 import DeleteResourceModal from "./modal/DeleteResourceModal";
@@ -34,7 +34,7 @@ import ContextContext from "../../../../context/ContextContext";
 import {faEdit, faTrash, faFile, faCodeBranch} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
-const { SearchBar } = Search;
+// const { SearchBar } = Search;
 const SELECT = true;
 const DESELECT = false;
 
@@ -214,7 +214,7 @@ class RestResource extends PureComponent {
                             <h3 className="panel-title">Methods</h3>
                         </div>
                         <div className="table-result">
-                            <ToolkitProvider bootstrap4
+                            {/* <ToolkitProvider bootstrap4
                                              columns={ this.columns}
                                              data={this.state.resource.methods}
                                              keyField="id"
@@ -232,7 +232,7 @@ class RestResource extends PureComponent {
                                                             pagination={ PaginationFactory() }/>
                                         </div>
                                     )}
-                            </ToolkitProvider>
+                            </ToolkitProvider> */}
                             <AuthenticationContext.Consumer>
                                 {context => (
                                     <div className="panel-buttons">

--- a/web/web-frontend/src/components/project/rest/resource/RestResource.js
+++ b/web/web-frontend/src/components/project/rest/resource/RestResource.js
@@ -17,9 +17,7 @@
 import React, {PureComponent} from 'react';
 import {Link} from "react-router-dom";
 import axios from "axios";
-// import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from '../../../utility/DataTable';
 import validateErrorResponse from "../../../../utility/HttpResponseValidator";
 import DeleteMethodsModal from "./modal/DeleteMethodsModal";
 import DeleteResourceModal from "./modal/DeleteResourceModal";
@@ -34,7 +32,6 @@ import ContextContext from "../../../../context/ContextContext";
 import {faEdit, faTrash, faFile, faCodeBranch} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
-// const { SearchBar } = Search;
 const SELECT = true;
 const DESELECT = false;
 
@@ -214,25 +211,16 @@ class RestResource extends PureComponent {
                             <h3 className="panel-title">Methods</h3>
                         </div>
                         <div className="table-result">
-                            {/* <ToolkitProvider bootstrap4
-                                             columns={ this.columns}
-                                             data={this.state.resource.methods}
-                                             keyField="id"
-                                             search>
-                                {
-                                    (props) => (
-                                        <div>
-                                            <div>
-                                                <SearchBar {...props.searchProps} className={"table-filter-field"}/>
-                                            </div>
-                                            <BootstrapTable {...props.baseProps} bootstrap4
-                                                            data={this.state.resource.methods} columns={this.columns}
-                                                            defaultSorted={this.defaultSort} keyField='id' hover
-                                                            selectRow={this.selectRow}
-                                                            pagination={ PaginationFactory() }/>
-                                        </div>
-                                    )}
-                            </ToolkitProvider> */}
+                            <DataTable
+                                columns={this.columns}
+                                data={this.state.resource.methods}
+                                keyField="id"
+                                search
+                                defaultSort={this.defaultSort}
+                                noDataIndication="No methods"
+                                selectRow={this.selectRow}
+                                pagination
+                            ></DataTable>
                             <AuthenticationContext.Consumer>
                                 {context => (
                                     <div className="panel-buttons">

--- a/web/web-frontend/src/components/project/rest/resource/modal/DeleteMethodsModal.js
+++ b/web/web-frontend/src/components/project/rest/resource/modal/DeleteMethodsModal.js
@@ -17,9 +17,7 @@
 import React, {PureComponent} from "react";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../../../utility/DataTable";
 import {faTrash} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
@@ -75,20 +73,13 @@ class DeleteMethodsModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want delete the following methods?</p>
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.columns}
-                                                 data={ this.props.selectedMethods }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedMethods} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.columns}
+                                    data={this.props.selectedMethods}
+                                    keyField="id"
+                                    defaultSort={this.defaultSort}
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                         </div>
                         <div className="modal-footer">

--- a/web/web-frontend/src/components/project/rest/resource/modal/DeleteMethodsModal.js
+++ b/web/web-frontend/src/components/project/rest/resource/modal/DeleteMethodsModal.js
@@ -17,9 +17,9 @@
 import React, {PureComponent} from "react";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import {faTrash} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
@@ -75,7 +75,7 @@ class DeleteMethodsModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want delete the following methods?</p>
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.columns}
                                                  data={ this.props.selectedMethods }
                                                  keyField="id">
@@ -88,7 +88,7 @@ class DeleteMethodsModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                         </div>
                         <div className="modal-footer">

--- a/web/web-frontend/src/components/project/rest/resource/modal/UpdateEndpointModal.js
+++ b/web/web-frontend/src/components/project/rest/resource/modal/UpdateEndpointModal.js
@@ -15,9 +15,7 @@
  */
 
 import React, {PureComponent} from "react";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../../../utility/DataTable";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import preventEnterEvent from "../../../../../utility/KeyboardUtility";
@@ -89,20 +87,13 @@ class UpdateEndpointModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the endpoint for the following methods?</p>
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.columns}
-                                                 data={ this.props.selectedMethods }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedMethods} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.columns}
+                                    data={this.props.selectedMethods}
+                                    keyField="id"
+                                    defaultSort={this.defaultSort}
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Endpoint</label>

--- a/web/web-frontend/src/components/project/rest/resource/modal/UpdateEndpointModal.js
+++ b/web/web-frontend/src/components/project/rest/resource/modal/UpdateEndpointModal.js
@@ -15,9 +15,9 @@
  */
 
 import React, {PureComponent} from "react";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import preventEnterEvent from "../../../../../utility/KeyboardUtility";
@@ -89,7 +89,7 @@ class UpdateEndpointModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the endpoint for the following methods?</p>
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.columns}
                                                  data={ this.props.selectedMethods }
                                                  keyField="id">
@@ -102,7 +102,7 @@ class UpdateEndpointModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Endpoint</label>

--- a/web/web-frontend/src/components/project/rest/resource/modal/UpdateStatusModal.js
+++ b/web/web-frontend/src/components/project/rest/resource/modal/UpdateStatusModal.js
@@ -15,9 +15,9 @@
  */
 
 import React, {PureComponent} from "react";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import {methodStatusFormatter} from "../../utility/RestFormatter"
@@ -88,7 +88,7 @@ class UpdateStatusModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the status for the following methods?</p>
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.columns}
                                                  data={ this.props.selectedMethods }
                                                  keyField="id">
@@ -101,7 +101,7 @@ class UpdateStatusModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Status</label>

--- a/web/web-frontend/src/components/project/rest/resource/modal/UpdateStatusModal.js
+++ b/web/web-frontend/src/components/project/rest/resource/modal/UpdateStatusModal.js
@@ -15,9 +15,7 @@
  */
 
 import React, {PureComponent} from "react";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../../../utility/DataTable";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import {methodStatusFormatter} from "../../utility/RestFormatter"
@@ -88,20 +86,13 @@ class UpdateStatusModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the status for the following methods?</p>
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.columns}
-                                                 data={ this.props.selectedMethods }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedMethods} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.columns}
+                                    data={this.props.selectedMethods}
+                                    keyField="id"
+                                    defaultSort={this.defaultSort}
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Status</label>

--- a/web/web-frontend/src/components/project/soap/operation/SoapOperation.js
+++ b/web/web-frontend/src/components/project/soap/operation/SoapOperation.js
@@ -17,9 +17,7 @@
 import React, {PureComponent} from 'react';
 import {Link} from "react-router-dom";
 import axios from "axios";
-// import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from '../../../utility/DataTable';
 import validateErrorResponse from "../../../../utility/HttpResponseValidator";
 import AuthenticationContext from "../../../../context/AuthenticationContext";
 import {isOnlyReader} from "../../../../utility/AuthorizeUtility";
@@ -34,7 +32,6 @@ import ContextContext from "../../../../context/ContextContext";
 import {faTrash, faFile, faEdit, faCopy} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
-// const { SearchBar } = Search;
 const SELECT = true;
 const DESELECT = false;
 
@@ -300,26 +297,16 @@ class SoapOperation extends PureComponent {
                             <h3 className="panel-title">Mock responses</h3>
                         </div>
                         <div className="table-result">
-                            {/* <ToolkitProvider bootstrap4
-                                             columns={ this.columns}
-                                             data={this.state.operation.mockResponses}
-                                             keyField="id"
-                                             search>
-                                {
-                                    (props) => (
-                                        <div>
-                                            <div>
-                                                <SearchBar {...props.searchProps} className={"table-filter-field"}/>
-                                            </div>
-                                            <BootstrapTable {...props.baseProps} bootstrap4
-                                                            data={this.state.operation.mockResponses} columns={this.columns}
-                                                            defaultSorted={this.defaultSort} keyField='id' hover
-                                                            selectRow={this.selectRow}
-                                                            noDataIndication="No mocked responses"
-                                                            pagination={ PaginationFactory() }/>
-                                        </div>
-                                    )}
-                            </ToolkitProvider> */}
+                            <DataTable
+                                columns={this.columns}
+                                data={this.state.operation.mockResponses}
+                                keyField="id"
+                                search
+                                defaultSort={this.defaultSort}
+                                selectRow={this.selectRow}
+                                noDataIndication="No mocked responses"
+                                pagination
+                            ></DataTable>
                             <AuthenticationContext.Consumer>
                                 {context => (
                                     <div className="panel-buttons">

--- a/web/web-frontend/src/components/project/soap/operation/SoapOperation.js
+++ b/web/web-frontend/src/components/project/soap/operation/SoapOperation.js
@@ -17,9 +17,9 @@
 import React, {PureComponent} from 'react';
 import {Link} from "react-router-dom";
 import axios from "axios";
-import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import validateErrorResponse from "../../../../utility/HttpResponseValidator";
 import AuthenticationContext from "../../../../context/AuthenticationContext";
 import {isOnlyReader} from "../../../../utility/AuthorizeUtility";
@@ -34,7 +34,7 @@ import ContextContext from "../../../../context/ContextContext";
 import {faTrash, faFile, faEdit, faCopy} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
-const { SearchBar } = Search;
+// const { SearchBar } = Search;
 const SELECT = true;
 const DESELECT = false;
 
@@ -300,7 +300,7 @@ class SoapOperation extends PureComponent {
                             <h3 className="panel-title">Mock responses</h3>
                         </div>
                         <div className="table-result">
-                            <ToolkitProvider bootstrap4
+                            {/* <ToolkitProvider bootstrap4
                                              columns={ this.columns}
                                              data={this.state.operation.mockResponses}
                                              keyField="id"
@@ -319,7 +319,7 @@ class SoapOperation extends PureComponent {
                                                             pagination={ PaginationFactory() }/>
                                         </div>
                                     )}
-                            </ToolkitProvider>
+                            </ToolkitProvider> */}
                             <AuthenticationContext.Consumer>
                                 {context => (
                                     <div className="panel-buttons">

--- a/web/web-frontend/src/components/project/soap/operation/modal/DeleteMockResponsesModal.js
+++ b/web/web-frontend/src/components/project/soap/operation/modal/DeleteMockResponsesModal.js
@@ -17,9 +17,7 @@
 import React, {PureComponent} from "react";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../../../utility/DataTable";
 import {faTrash} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
@@ -75,20 +73,13 @@ class DeleteMockResponsesModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want delete the following mockResponses?</p>
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.columns}
-                                                 data={ this.props.selectedMockResponses }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedMockResponses} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.columns}
+                                    data={this.props.selectedMockResponses}
+                                    keyField="id"
+                                    defaultSort={this.defaultSort}
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                         </div>
                         <div className="modal-footer">

--- a/web/web-frontend/src/components/project/soap/operation/modal/DeleteMockResponsesModal.js
+++ b/web/web-frontend/src/components/project/soap/operation/modal/DeleteMockResponsesModal.js
@@ -17,9 +17,9 @@
 import React, {PureComponent} from "react";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import {faTrash} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
@@ -75,7 +75,7 @@ class DeleteMockResponsesModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want delete the following mockResponses?</p>
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.columns}
                                                  data={ this.props.selectedMockResponses }
                                                  keyField="id">
@@ -88,7 +88,7 @@ class DeleteMockResponsesModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                         </div>
                         <div className="modal-footer">

--- a/web/web-frontend/src/components/project/soap/operation/modal/DuplicateMockResponseModal.js
+++ b/web/web-frontend/src/components/project/soap/operation/modal/DuplicateMockResponseModal.js
@@ -17,9 +17,7 @@
 import React, {PureComponent} from "react";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../../../utility/DataTable";
 import {faCheckCircle} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
@@ -77,20 +75,13 @@ class DuplicateMockResponseModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want to duplicate the following mock responses?</p>
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.columns}
-                                                 data={ this.props.selectedMockResponses }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedMockResponses} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.columns}
+                                    data={this.props.selectedMockResponses}
+                                    keyField="id"
+                                    defaultSort={this.defaultSort}
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                         </div>
                         <div className="modal-footer">

--- a/web/web-frontend/src/components/project/soap/operation/modal/DuplicateMockResponseModal.js
+++ b/web/web-frontend/src/components/project/soap/operation/modal/DuplicateMockResponseModal.js
@@ -17,9 +17,9 @@
 import React, {PureComponent} from "react";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import {faCheckCircle} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
@@ -77,7 +77,7 @@ class DuplicateMockResponseModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want to duplicate the following mock responses?</p>
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.columns}
                                                  data={ this.props.selectedMockResponses }
                                                  keyField="id">
@@ -90,7 +90,7 @@ class DuplicateMockResponseModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                         </div>
                         <div className="modal-footer">

--- a/web/web-frontend/src/components/project/soap/operation/modal/UpdateStatusModal.js
+++ b/web/web-frontend/src/components/project/soap/operation/modal/UpdateStatusModal.js
@@ -17,9 +17,7 @@
 import React, {PureComponent} from "react";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../../../utility/DataTable";
 import {mockResponseStatusFormatter} from "../../utility/SoapFormatter"
 import {faCheckCircle} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
@@ -88,20 +86,13 @@ class UpdateStatusModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the status for the following mock responses?</p>
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.columns}
-                                                 data={ this.props.selectedMockResponses }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedMockResponses} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.columns}
+                                    data={this.props.selectedMockResponses}
+                                    keyField="id"
+                                    defaultSort={this.defaultSort}
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Status</label>

--- a/web/web-frontend/src/components/project/soap/operation/modal/UpdateStatusModal.js
+++ b/web/web-frontend/src/components/project/soap/operation/modal/UpdateStatusModal.js
@@ -17,9 +17,9 @@
 import React, {PureComponent} from "react";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import {mockResponseStatusFormatter} from "../../utility/SoapFormatter"
 import {faCheckCircle} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
@@ -88,7 +88,7 @@ class UpdateStatusModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the status for the following mock responses?</p>
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.columns}
                                                  data={ this.props.selectedMockResponses }
                                                  keyField="id">
@@ -101,7 +101,7 @@ class UpdateStatusModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Status</label>

--- a/web/web-frontend/src/components/project/soap/port/SoapPort.js
+++ b/web/web-frontend/src/components/project/soap/port/SoapPort.js
@@ -17,9 +17,7 @@
 import React, {PureComponent} from 'react';
 import {Link} from "react-router-dom";
 import axios from "axios";
-// import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from '../../../utility/DataTable';
 import validateErrorResponse from "../../../../utility/HttpResponseValidator";
 import AuthenticationContext from "../../../../context/AuthenticationContext";
 import UpdatePortModal from "./modal/UpdatePortModal";
@@ -32,7 +30,6 @@ import ContextContext from "../../../../context/ContextContext";
 import {faTrash, faEdit, faCodeBranch} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
-// const { SearchBar } = Search;
 const SELECT = true;
 const DESELECT = false;
 
@@ -251,27 +248,16 @@ class SoapPort extends PureComponent {
                             <h3 className="panel-title">Operations</h3>
                         </div>
                         <div className="table-result">
-                            {/* <ToolkitProvider bootstrap4
-                                             columns={ this.columns}
-                                             data={this.state.port.operations}
-                                             keyField="id"
-                                             search>
-                                {
-                                    (props) => (
-                                        <div>
-                                            <div>
-                                                <SearchBar {...props.searchProps} className={"table-filter-field"}/>
-                                            </div>
-                                            <BootstrapTable {...props.baseProps} bootstrap4
-                                                            data={this.state.port.operations} columns={this.columns}
-                                                            defaultSorted={this.defaultSort} keyField='id' hover
-                                                            selectRow={this.selectRow}
-                                                            striped
-                                                            noDataIndication="Table is Empty"
-                                                            pagination={ PaginationFactory() }/>
-                                        </div>
-                                    )}
-                            </ToolkitProvider> */}
+                            <DataTable
+                                columns={this.columns}
+                                data={this.state.port.operations}
+                                keyField="id"
+                                search
+                                defaultSort={this.defaultSort}
+                                selectRow={this.selectRow}
+                                noDataIndication="Table is Empty"
+                                pagination
+                            ></DataTable>
                             <AuthenticationContext.Consumer>
                                 {context => (
                                     <div className="panel-buttons">

--- a/web/web-frontend/src/components/project/soap/port/SoapPort.js
+++ b/web/web-frontend/src/components/project/soap/port/SoapPort.js
@@ -17,9 +17,9 @@
 import React, {PureComponent} from 'react';
 import {Link} from "react-router-dom";
 import axios from "axios";
-import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import validateErrorResponse from "../../../../utility/HttpResponseValidator";
 import AuthenticationContext from "../../../../context/AuthenticationContext";
 import UpdatePortModal from "./modal/UpdatePortModal";
@@ -32,7 +32,7 @@ import ContextContext from "../../../../context/ContextContext";
 import {faTrash, faEdit, faCodeBranch} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
-const { SearchBar } = Search;
+// const { SearchBar } = Search;
 const SELECT = true;
 const DESELECT = false;
 
@@ -251,7 +251,7 @@ class SoapPort extends PureComponent {
                             <h3 className="panel-title">Operations</h3>
                         </div>
                         <div className="table-result">
-                            <ToolkitProvider bootstrap4
+                            {/* <ToolkitProvider bootstrap4
                                              columns={ this.columns}
                                              data={this.state.port.operations}
                                              keyField="id"
@@ -271,7 +271,7 @@ class SoapPort extends PureComponent {
                                                             pagination={ PaginationFactory() }/>
                                         </div>
                                     )}
-                            </ToolkitProvider>
+                            </ToolkitProvider> */}
                             <AuthenticationContext.Consumer>
                                 {context => (
                                     <div className="panel-buttons">

--- a/web/web-frontend/src/components/project/soap/port/modal/UpdateEndpointModal.js
+++ b/web/web-frontend/src/components/project/soap/port/modal/UpdateEndpointModal.js
@@ -15,9 +15,9 @@
  */
 
 import React, {PureComponent} from "react";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import {faCheckCircle} from "@fortawesome/free-solid-svg-icons";
@@ -85,7 +85,7 @@ class UpdateEndpointModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the endpoint for the following operations?</p>
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.columns}
                                                  data={ this.props.selectedOperations }
                                                  keyField="id">
@@ -98,7 +98,7 @@ class UpdateEndpointModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Endpoint</label>

--- a/web/web-frontend/src/components/project/soap/port/modal/UpdateEndpointModal.js
+++ b/web/web-frontend/src/components/project/soap/port/modal/UpdateEndpointModal.js
@@ -15,9 +15,7 @@
  */
 
 import React, {PureComponent} from "react";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../../../utility/DataTable";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import {faCheckCircle} from "@fortawesome/free-solid-svg-icons";
@@ -85,20 +83,13 @@ class UpdateEndpointModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the endpoint for the following operations?</p>
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.columns}
-                                                 data={ this.props.selectedOperations }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedOperations} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.columns}
+                                    data={this.props.selectedOperations}
+                                    keyField="id"
+                                    defaultSort={this.defaultSort}
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Endpoint</label>

--- a/web/web-frontend/src/components/project/soap/port/modal/UpdateStatusModal.js
+++ b/web/web-frontend/src/components/project/soap/port/modal/UpdateStatusModal.js
@@ -15,9 +15,7 @@
  */
 
 import React, {PureComponent} from "react";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../../../utility/DataTable";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import {operationStatusFormatter} from "../../utility/SoapFormatter"
@@ -87,20 +85,13 @@ class UpdateStatusModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the status for the following operations?</p>
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.columns}
-                                                 data={ this.props.selectedOperations }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedOperations} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.columns}
+                                    data={this.props.selectedOperations}
+                                    keyField="id"
+                                    defaultSort={this.defaultSort}
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Status</label>

--- a/web/web-frontend/src/components/project/soap/port/modal/UpdateStatusModal.js
+++ b/web/web-frontend/src/components/project/soap/port/modal/UpdateStatusModal.js
@@ -15,9 +15,9 @@
  */
 
 import React, {PureComponent} from "react";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import {operationStatusFormatter} from "../../utility/SoapFormatter"
@@ -87,7 +87,7 @@ class UpdateStatusModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the status for the following operations?</p>
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.columns}
                                                  data={ this.props.selectedOperations }
                                                  keyField="id">
@@ -100,7 +100,7 @@ class UpdateStatusModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Status</label>

--- a/web/web-frontend/src/components/project/soap/project/SoapProject.js
+++ b/web/web-frontend/src/components/project/soap/project/SoapProject.js
@@ -17,9 +17,9 @@
 import React, {PureComponent} from 'react';
 import {Link} from "react-router-dom";
 import axios from "axios";
-import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import validateErrorResponse from "../../../../utility/HttpResponseValidator";
 import Badge from "react-bootstrap/Badge";
 import AuthenticationContext from "../../../../context/AuthenticationContext";
@@ -33,7 +33,7 @@ import UploadWSDLModal from "./modal/UploadWSDLModal"
 import {faEdit, faTrash, faCloudDownloadAlt, faCloudUploadAlt, faCodeBranch} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
-const { SearchBar } = Search;
+// const { SearchBar } = Search;
 
 const SELECT = true;
 const DESELECT = false;
@@ -313,7 +313,7 @@ class SoapProject extends PureComponent {
                             <h3 className="panel-title">Ports</h3>
                         </div>
                         <div className="table-result">
-                            <ToolkitProvider bootstrap4
+                            {/* <ToolkitProvider bootstrap4
                                              columns={ this.columns}
                                              data={this.state.project.ports}
                                              keyField="id"
@@ -332,7 +332,7 @@ class SoapProject extends PureComponent {
                                                             pagination={ PaginationFactory() }/>
                                         </div>
                                     )}
-                            </ToolkitProvider>
+                            </ToolkitProvider> */}
                             <AuthenticationContext.Consumer>
                                 {context => (
                                     <div className="panel-buttons">
@@ -355,7 +355,7 @@ class SoapProject extends PureComponent {
                             <h3 className="panel-title">Resources</h3>
                         </div>
                         <div className="table-result">
-                            <ToolkitProvider bootstrap4
+                            {/* <ToolkitProvider bootstrap4
                                              columns={ this.resourceColumns}
                                              data={this.state.project.resources}
                                              keyField="id"
@@ -370,7 +370,7 @@ class SoapProject extends PureComponent {
                                                             pagination={ PaginationFactory() }/>
                                         </div>
                                     )}
-                            </ToolkitProvider>
+                            </ToolkitProvider> */}
                         </div>
                     </div>
                 </section>

--- a/web/web-frontend/src/components/project/soap/project/SoapProject.js
+++ b/web/web-frontend/src/components/project/soap/project/SoapProject.js
@@ -17,9 +17,7 @@
 import React, {PureComponent} from 'react';
 import {Link} from "react-router-dom";
 import axios from "axios";
-// import ToolkitProvider, {Search} from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from '../../../utility/DataTable';
 import validateErrorResponse from "../../../../utility/HttpResponseValidator";
 import Badge from "react-bootstrap/Badge";
 import AuthenticationContext from "../../../../context/AuthenticationContext";
@@ -33,7 +31,6 @@ import UploadWSDLModal from "./modal/UploadWSDLModal"
 import {faEdit, faTrash, faCloudDownloadAlt, faCloudUploadAlt, faCodeBranch} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
-// const { SearchBar } = Search;
 
 const SELECT = true;
 const DESELECT = false;
@@ -313,26 +310,16 @@ class SoapProject extends PureComponent {
                             <h3 className="panel-title">Ports</h3>
                         </div>
                         <div className="table-result">
-                            {/* <ToolkitProvider bootstrap4
-                                             columns={ this.columns}
-                                             data={this.state.project.ports}
-                                             keyField="id"
-                                             search>
-                                {
-                                    (props) => (
-                                        <div>
-                                            <div>
-                                                <SearchBar {...props.searchProps} className={"table-filter-field"}/>
-                                            </div>
-                                            <BootstrapTable {...props.baseProps} bootstrap4
-                                                            data={this.state.project.ports} columns={this.columns}
-                                                            defaultSorted={this.defaultSort} keyField='id' hover
-                                                            selectRow={this.selectRow}
-                                                            noDataIndication="Upload a WSDL file to load ports"
-                                                            pagination={ PaginationFactory() }/>
-                                        </div>
-                                    )}
-                            </ToolkitProvider> */}
+                            <DataTable
+                                columns={this.columns}
+                                data={this.state.project.ports}
+                                keyField="id"
+                                search
+                                defaultSort={this.defaultSort}
+                                selectRow={this.selectRow}
+                                noDataIndication="Upload a WSDL file to load ports"
+                                pagination
+                            ></DataTable>
                             <AuthenticationContext.Consumer>
                                 {context => (
                                     <div className="panel-buttons">
@@ -355,22 +342,15 @@ class SoapProject extends PureComponent {
                             <h3 className="panel-title">Resources</h3>
                         </div>
                         <div className="table-result">
-                            {/* <ToolkitProvider bootstrap4
-                                             columns={ this.resourceColumns}
-                                             data={this.state.project.resources}
-                                             keyField="id"
-                                             search>
-                                {
-                                    (props) => (
-                                        <div>
-                                            <BootstrapTable {...props.baseProps} bootstrap4
-                                                            data={this.state.project.resources} columns={this.resourceColumns}
-                                                            defaultSorted={this.defaultSort} keyField='id' hover
-                                                            noDataIndication="Upload a WSDL file to load ports"
-                                                            pagination={ PaginationFactory() }/>
-                                        </div>
-                                    )}
-                            </ToolkitProvider> */}
+                            <DataTable
+                                columns={this.resourceColumns}
+                                data={this.state.project.resources}
+                                keyField="id"
+                                search
+                                defaultSort={this.defaultSort}
+                                noDataIndication="Upload a WSDL file to load ports"
+                                pagination
+                            ></DataTable>
                         </div>
                     </div>
                 </section>

--- a/web/web-frontend/src/components/project/soap/project/modal/DeletePortsModal.js
+++ b/web/web-frontend/src/components/project/soap/project/modal/DeletePortsModal.js
@@ -15,9 +15,9 @@
  */
 
 import React, {PureComponent} from "react";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import {faTrash} from "@fortawesome/free-solid-svg-icons";
@@ -74,7 +74,7 @@ class DeletePortsModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want delete the following ports?</p>
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.columns}
                                                  data={ this.props.selectedPorts }
                                                  keyField="id">
@@ -87,7 +87,7 @@ class DeletePortsModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                         </div>
                         <div className="modal-footer">

--- a/web/web-frontend/src/components/project/soap/project/modal/DeletePortsModal.js
+++ b/web/web-frontend/src/components/project/soap/project/modal/DeletePortsModal.js
@@ -15,9 +15,7 @@
  */
 
 import React, {PureComponent} from "react";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../../../utility/DataTable";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import {faTrash} from "@fortawesome/free-solid-svg-icons";
@@ -74,20 +72,13 @@ class DeletePortsModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want delete the following ports?</p>
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.columns}
-                                                 data={ this.props.selectedPorts }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedPorts} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.columns}
+                                    data={this.props.selectedPorts}
+                                    keyField="id"
+                                    defaultSort={this.defaultSort}
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                         </div>
                         <div className="modal-footer">

--- a/web/web-frontend/src/components/project/soap/project/modal/UpdateEndpointModal.js
+++ b/web/web-frontend/src/components/project/soap/project/modal/UpdateEndpointModal.js
@@ -15,15 +15,12 @@
  */
 
 import React, {PureComponent} from "react";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../../../utility/DataTable";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import preventEnterEvent from "../../../../../utility/KeyboardUtility";
 import {faCheckCircle} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import DataTable from "../../../../utility/DataTable";
 
 
 class UpdateEndpointModal extends PureComponent {

--- a/web/web-frontend/src/components/project/soap/project/modal/UpdateEndpointModal.js
+++ b/web/web-frontend/src/components/project/soap/project/modal/UpdateEndpointModal.js
@@ -23,6 +23,7 @@ import validateErrorResponse from "../../../../../utility/HttpResponseValidator"
 import preventEnterEvent from "../../../../../utility/KeyboardUtility";
 import {faCheckCircle} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import DataTable from "../../../../utility/DataTable";
 
 
 class UpdateEndpointModal extends PureComponent {
@@ -88,20 +89,13 @@ class UpdateEndpointModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the endpoint for the following ports?</p>
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.updateColumns}
-                                                 data={ this.props.selectedPorts }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedPorts} columns={this.updateColumns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.updateColumns}
+                                    data={this.props.selectedPorts}
+                                    keyField="id"
+                                    defaultSort={this.defaultSort}
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Endpoint</label>

--- a/web/web-frontend/src/components/project/soap/project/modal/UpdateEndpointModal.js
+++ b/web/web-frontend/src/components/project/soap/project/modal/UpdateEndpointModal.js
@@ -15,9 +15,9 @@
  */
 
 import React, {PureComponent} from "react";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import preventEnterEvent from "../../../../../utility/KeyboardUtility";
@@ -88,7 +88,7 @@ class UpdateEndpointModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the endpoint for the following ports?</p>
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.updateColumns}
                                                  data={ this.props.selectedPorts }
                                                  keyField="id">
@@ -101,7 +101,7 @@ class UpdateEndpointModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Endpoint</label>

--- a/web/web-frontend/src/components/project/soap/project/modal/UpdateStatusModal.js
+++ b/web/web-frontend/src/components/project/soap/project/modal/UpdateStatusModal.js
@@ -15,9 +15,7 @@
  */
 
 import React, {PureComponent} from "react";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../../../utility/DataTable";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import {operationStatusFormatter} from "../../utility/SoapFormatter";
@@ -88,20 +86,13 @@ class UpdateStatusModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the status for the following ports?</p>
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.columns}
-                                                 data={ this.props.selectedPorts }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedPorts} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.columns}
+                                    data={this.props.selectedPorts}
+                                    keyField="id"
+                                    defaultSort={this.defaultSort}
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Status</label>

--- a/web/web-frontend/src/components/project/soap/project/modal/UpdateStatusModal.js
+++ b/web/web-frontend/src/components/project/soap/project/modal/UpdateStatusModal.js
@@ -15,9 +15,9 @@
  */
 
 import React, {PureComponent} from "react";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import axios from "axios";
 import validateErrorResponse from "../../../../../utility/HttpResponseValidator";
 import {operationStatusFormatter} from "../../utility/SoapFormatter";
@@ -88,7 +88,7 @@ class UpdateStatusModal extends PureComponent {
                         <div className="modal-body">
                             <p>Do you want update the status for the following ports?</p>
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.columns}
                                                  data={ this.props.selectedPorts }
                                                  keyField="id">
@@ -101,7 +101,7 @@ class UpdateStatusModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                             <div className="form-group row">
                                 <label className="col-sm-2 col-form-label">Status</label>

--- a/web/web-frontend/src/components/project/utility/HeaderComponent.js
+++ b/web/web-frontend/src/components/project/utility/HeaderComponent.js
@@ -15,8 +15,7 @@
  */
 
 import React, {PureComponent} from "react";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
+import DataTable from "../../utility/DataTable";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faPlus, faTrash} from "@fortawesome/free-solid-svg-icons";
 
@@ -122,22 +121,15 @@ class HeaderComponent extends PureComponent {
                     </div>
                 </div>
                 <div className="table-result">
-                    {/* <ToolkitProvider bootstrap4
-                                     columns={ this.headerColumns}
-                                     data={this.props.httpHeaders}
-                                     keyField="name"
-                                     search>
-                        {
-                            (props) => (
-                                <div>
-                                    <BootstrapTable {...props.baseProps} bootstrap4
-                                                    data={this.props.httpHeaders} columns={this.headerColumns}
-                                                    defaultSorted={this.defaultSort} keyField='name' hover
-                                                    noDataIndication="No headers"
-                                                    selectRow={this.selectRow}/>
-                                </div>
-                            )}
-                    </ToolkitProvider> */}
+                    <DataTable
+                        columns={this.headerColumns}
+                        data={this.props.httpHeaders}
+                        keyField="name"
+                        search
+                        defaultSort={this.defaultSort}
+                        noDataIndication="No headers"
+                        selectRow={this.selectRow}
+                    ></DataTable>
                 </div>
             </div>
         )

--- a/web/web-frontend/src/components/project/utility/HeaderComponent.js
+++ b/web/web-frontend/src/components/project/utility/HeaderComponent.js
@@ -15,8 +15,8 @@
  */
 
 import React, {PureComponent} from "react";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faPlus, faTrash} from "@fortawesome/free-solid-svg-icons";
 
@@ -122,7 +122,7 @@ class HeaderComponent extends PureComponent {
                     </div>
                 </div>
                 <div className="table-result">
-                    <ToolkitProvider bootstrap4
+                    {/* <ToolkitProvider bootstrap4
                                      columns={ this.headerColumns}
                                      data={this.props.httpHeaders}
                                      keyField="name"
@@ -137,7 +137,7 @@ class HeaderComponent extends PureComponent {
                                                     selectRow={this.selectRow}/>
                                 </div>
                             )}
-                    </ToolkitProvider>
+                    </ToolkitProvider> */}
                 </div>
             </div>
         )

--- a/web/web-frontend/src/components/project/utility/HeaderQueryComponent.js
+++ b/web/web-frontend/src/components/project/utility/HeaderQueryComponent.js
@@ -15,8 +15,8 @@
  */
 
 import React, {PureComponent} from "react";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faPlus, faTrash} from "@fortawesome/free-solid-svg-icons";
 
@@ -180,7 +180,7 @@ class HeaderQueryComponent extends PureComponent {
                     </div>
                 </div>
                 <div className="table-result">
-                    <ToolkitProvider bootstrap4
+                    {/* <ToolkitProvider bootstrap4
                                      columns={ this.headerQueryColumns}
                                      data={this.props.headerQueries}
                                      keyField="header"
@@ -194,7 +194,7 @@ class HeaderQueryComponent extends PureComponent {
                                                     noDataIndication="No header queries"/>
                                 </div>
                             )}
-                    </ToolkitProvider>
+                    </ToolkitProvider> */}
                 </div>
             </div>
         )

--- a/web/web-frontend/src/components/project/utility/HeaderQueryComponent.js
+++ b/web/web-frontend/src/components/project/utility/HeaderQueryComponent.js
@@ -15,8 +15,7 @@
  */
 
 import React, {PureComponent} from "react";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
+import DataTable from "../../utility/DataTable";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faPlus, faTrash} from "@fortawesome/free-solid-svg-icons";
 
@@ -180,21 +179,13 @@ class HeaderQueryComponent extends PureComponent {
                     </div>
                 </div>
                 <div className="table-result">
-                    {/* <ToolkitProvider bootstrap4
-                                     columns={ this.headerQueryColumns}
-                                     data={this.props.headerQueries}
-                                     keyField="header"
-                                     search>
-                        {
-                            (props) => (
-                                <div>
-                                    <BootstrapTable {...props.baseProps} bootstrap4
-                                                    data={this.props.headerQueries} columns={this.headerQueryColumns}
-                                                    keyField='header' hover
-                                                    noDataIndication="No header queries"/>
-                                </div>
-                            )}
-                    </ToolkitProvider> */}
+                    <DataTable
+                        columns={this.headerQueryColumns}
+                        data={this.props.headerQueries}
+                        keyField="header"
+                        search
+                        noDataIndication="No header queries"
+                    ></DataTable>
                 </div>
             </div>
         )

--- a/web/web-frontend/src/components/project/utility/JsonPathComponent.js
+++ b/web/web-frontend/src/components/project/utility/JsonPathComponent.js
@@ -15,8 +15,8 @@
  */
 
 import React, {PureComponent} from "react";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faPlus, faTrash} from "@fortawesome/free-solid-svg-icons";
 
@@ -97,7 +97,7 @@ class JsonPathComponent extends PureComponent {
                     </div>
                 </div>
                 <div className="table-result">
-                    <ToolkitProvider bootstrap4
+                    {/* <ToolkitProvider bootstrap4
                                      columns={ this.jsonPathColumns}
                                      data={this.props.jsonPathExpressions}
                                      keyField="name"
@@ -112,7 +112,7 @@ class JsonPathComponent extends PureComponent {
                                                     selectRow={this.selectRow}/>
                                 </div>
                             )}
-                    </ToolkitProvider>
+                    </ToolkitProvider> */}
                 </div>
             </div>
         )

--- a/web/web-frontend/src/components/project/utility/JsonPathComponent.js
+++ b/web/web-frontend/src/components/project/utility/JsonPathComponent.js
@@ -15,8 +15,7 @@
  */
 
 import React, {PureComponent} from "react";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
+import DataTable from "../../utility/DataTable";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faPlus, faTrash} from "@fortawesome/free-solid-svg-icons";
 
@@ -97,22 +96,15 @@ class JsonPathComponent extends PureComponent {
                     </div>
                 </div>
                 <div className="table-result">
-                    {/* <ToolkitProvider bootstrap4
-                                     columns={ this.jsonPathColumns}
-                                     data={this.props.jsonPathExpressions}
-                                     keyField="name"
-                                     search>
-                        {
-                            (props) => (
-                                <div>
-                                    <BootstrapTable {...props.baseProps} bootstrap4
-                                                    data={this.props.jsonPathExpressions} columns={this.jsonPathColumns}
-                                                    defaultSorted={this.defaultSort} keyField='expression' hover
-                                                    noDataIndication="No JsonPaths"
-                                                    selectRow={this.selectRow}/>
-                                </div>
-                            )}
-                    </ToolkitProvider> */}
+                    <DataTable
+                        columns={this.jsonPathColumns}
+                        data={this.props.jsonPathExpressions}
+                        keyField="expression"
+                        search
+                        defaultSort={this.defaultSort}
+                        noDataIndication="No JsonPaths"
+                        selectRow={this.selectRow}
+                    ></DataTable>
                 </div>
             </div>
         )

--- a/web/web-frontend/src/components/project/utility/ParameterQueryComponent.js
+++ b/web/web-frontend/src/components/project/utility/ParameterQueryComponent.js
@@ -16,8 +16,7 @@
 
 import React, {PureComponent} from "react";
 import axios from "axios";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
+import DataTable from "../../utility/DataTable";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faPlus, faTrash} from "@fortawesome/free-solid-svg-icons";
 
@@ -228,21 +227,13 @@ class ParameterQueryComponent extends PureComponent {
                     </div>
                 </div>
                 <div className="table-result">
-                    {/* <ToolkitProvider bootstrap4
-                                     columns={ this.parameterQueryColumns}
-                                     data={this.props.parameterQueries}
-                                     keyField="parameter"
-                                     search>
-                        {
-                            (props) => (
-                                <div>
-                                    <BootstrapTable {...props.baseProps} bootstrap4
-                                                    data={this.props.parameterQueries} columns={this.parameterQueryColumns}
-                                                    keyField='parameter' hover
-                                                    noDataIndication="No parameter queries"/>
-                                </div>
-                            )}
-                    </ToolkitProvider> */}
+                    <DataTable
+                        columns={this.parameterQueryColumns}
+                        data={this.props.parameterQueries}
+                        keyField="parameter"
+                        search
+                        noDataIndication="No parameter queries"
+                    ></DataTable>
                 </div>
             </div>
         )

--- a/web/web-frontend/src/components/project/utility/ParameterQueryComponent.js
+++ b/web/web-frontend/src/components/project/utility/ParameterQueryComponent.js
@@ -16,8 +16,8 @@
 
 import React, {PureComponent} from "react";
 import axios from "axios";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faPlus, faTrash} from "@fortawesome/free-solid-svg-icons";
 
@@ -228,7 +228,7 @@ class ParameterQueryComponent extends PureComponent {
                     </div>
                 </div>
                 <div className="table-result">
-                    <ToolkitProvider bootstrap4
+                    {/* <ToolkitProvider bootstrap4
                                      columns={ this.parameterQueryColumns}
                                      data={this.props.parameterQueries}
                                      keyField="parameter"
@@ -242,7 +242,7 @@ class ParameterQueryComponent extends PureComponent {
                                                     noDataIndication="No parameter queries"/>
                                 </div>
                             )}
-                    </ToolkitProvider>
+                    </ToolkitProvider> */}
                 </div>
             </div>
         )

--- a/web/web-frontend/src/components/project/utility/XPathComponent.js
+++ b/web/web-frontend/src/components/project/utility/XPathComponent.js
@@ -15,8 +15,8 @@
  */
 
 import React, {PureComponent} from "react";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faPlus, faTrash} from "@fortawesome/free-solid-svg-icons";
 
@@ -97,7 +97,7 @@ class XPathComponent extends PureComponent {
                     </div>
                 </div>
                 <div className="table-result">
-                    <ToolkitProvider bootstrap4
+                    {/* <ToolkitProvider bootstrap4
                                      columns={ this.xpathColumns}
                                      data={this.props.xpathExpressions}
                                      keyField="name"
@@ -112,7 +112,7 @@ class XPathComponent extends PureComponent {
                                                     selectRow={this.selectRow}/>
                                 </div>
                             )}
-                    </ToolkitProvider>
+                    </ToolkitProvider> */}
                 </div>
             </div>
         )

--- a/web/web-frontend/src/components/project/utility/XPathComponent.js
+++ b/web/web-frontend/src/components/project/utility/XPathComponent.js
@@ -15,8 +15,7 @@
  */
 
 import React, {PureComponent} from "react";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
+import DataTable from "../../utility/DataTable";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faPlus, faTrash} from "@fortawesome/free-solid-svg-icons";
 
@@ -97,22 +96,15 @@ class XPathComponent extends PureComponent {
                     </div>
                 </div>
                 <div className="table-result">
-                    {/* <ToolkitProvider bootstrap4
-                                     columns={ this.xpathColumns}
-                                     data={this.props.xpathExpressions}
-                                     keyField="name"
-                                     search>
-                        {
-                            (props) => (
-                                <div>
-                                    <BootstrapTable {...props.baseProps} bootstrap4
-                                                    data={this.props.xpathExpressions} columns={this.xpathColumns}
-                                                    defaultSorted={this.defaultSort} keyField='expression' hover
-                                                    noDataIndication="No XPaths"
-                                                    selectRow={this.selectRow}/>
-                                </div>
-                            )}
-                    </ToolkitProvider> */}
+                    <DataTable
+                        columns={this.xpathColumns}
+                        data={this.props.xpathExpressions}
+                        keyField="expression"
+                        search
+                        defaultSort={this.defaultSort}
+                        noDataIndication="No XPaths"
+                        selectRow={this.selectRow}
+                    ></DataTable>
                 </div>
             </div>
         )

--- a/web/web-frontend/src/components/project/utility/modal/ValidateExpressionModal.js
+++ b/web/web-frontend/src/components/project/utility/modal/ValidateExpressionModal.js
@@ -15,9 +15,9 @@
  */
 
 import React, {PureComponent} from "react";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import axios from "axios";
 import validateErrorResponse from "../../../../utility/HttpResponseValidator";
 import {faCheckCircle} from "@fortawesome/free-solid-svg-icons";

--- a/web/web-frontend/src/components/project/utility/modal/ValidateExpressionModal.js
+++ b/web/web-frontend/src/components/project/utility/modal/ValidateExpressionModal.js
@@ -15,9 +15,6 @@
  */
 
 import React, {PureComponent} from "react";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
 import axios from "axios";
 import validateErrorResponse from "../../../../utility/HttpResponseValidator";
 import {faCheckCircle} from "@fortawesome/free-solid-svg-icons";

--- a/web/web-frontend/src/components/user/UserOverview.js
+++ b/web/web-frontend/src/components/user/UserOverview.js
@@ -15,9 +15,9 @@
  */
 
 import React, {PureComponent} from 'react';
-import BootstrapTable from 'react-bootstrap-table-next';
-import ToolkitProvider, {Search} from 'react-bootstrap-table2-toolkit';
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import BootstrapTable from 'react-bootstrap-table-next';
+// import ToolkitProvider, {Search} from 'react-bootstrap-table2-toolkit';
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import axios from "axios";
 import {Link} from "react-router-dom";
 import validateErrorResponse from "../../utility/HttpResponseValidator";
@@ -27,7 +27,7 @@ import {userStatusFormatter, userRoleFormatter} from "../user/utility/UserFormat
 import {faUserPlus, faUserMinus} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
-const { SearchBar } = Search;
+// const { SearchBar } = Search;
 
 const SELECT = true;
 const DESELECT = false;
@@ -227,7 +227,7 @@ class UserOverview extends PureComponent {
                     </div>
                     <div className="panel panel-primary table-panel">
                         <div className="table-result">
-                            <ToolkitProvider bootstrap4
+                            {/* <ToolkitProvider bootstrap4
                                              columns={ this.columns}
                                              data={ this.state.users }
                                              keyField="id"
@@ -248,7 +248,7 @@ class UserOverview extends PureComponent {
                                             </div>
                                         </div>
                                     )}
-                            </ToolkitProvider>
+                            </ToolkitProvider> */}
                         </div>
                         <div className="table-result">
                             <div className="panel-buttons">

--- a/web/web-frontend/src/components/user/UserOverview.js
+++ b/web/web-frontend/src/components/user/UserOverview.js
@@ -15,9 +15,7 @@
  */
 
 import React, {PureComponent} from 'react';
-// import BootstrapTable from 'react-bootstrap-table-next';
-// import ToolkitProvider, {Search} from 'react-bootstrap-table2-toolkit';
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from '../utility/DataTable';
 import axios from "axios";
 import {Link} from "react-router-dom";
 import validateErrorResponse from "../../utility/HttpResponseValidator";
@@ -27,7 +25,6 @@ import {userStatusFormatter, userRoleFormatter} from "../user/utility/UserFormat
 import {faUserPlus, faUserMinus} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
-// const { SearchBar } = Search;
 
 const SELECT = true;
 const DESELECT = false;
@@ -227,28 +224,16 @@ class UserOverview extends PureComponent {
                     </div>
                     <div className="panel panel-primary table-panel">
                         <div className="table-result">
-                            {/* <ToolkitProvider bootstrap4
-                                             columns={ this.columns}
-                                             data={ this.state.users }
-                                             keyField="id"
-                                             search>
-                                {
-                                    (props) => (
-                                        <div>
-                                            <div>
-                                                <SearchBar { ...props.searchProps } className={"table-filter-field"} />
-                                            </div>
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.state.users} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                selectRow={ this.selectRow }
-                                                                striped
-                                                                noDataIndication="Click on 'New user' button to create a new user"
-                                                                pagination={ PaginationFactory() }/>
-                                            </div>
-                                        </div>
-                                    )}
-                            </ToolkitProvider> */}
+                            <DataTable
+                                columns={this.columns}
+                                data={this.state.users}
+                                keyField="id"
+                                search
+                                defaultSort={this.defaultSort}
+                                selectRow={this.selectRow}
+                                noDataIndication="Click on 'New user' button to create a new user"
+                                pagination
+                            ></DataTable>
                         </div>
                         <div className="table-result">
                             <div className="panel-buttons">

--- a/web/web-frontend/src/components/user/modal/DeleteUsersModal.js
+++ b/web/web-frontend/src/components/user/modal/DeleteUsersModal.js
@@ -17,9 +17,9 @@
 import React, {PureComponent} from "react";
 import axios from "axios";
 import validateErrorResponse from "../../../utility/HttpResponseValidator";
-import ToolkitProvider from "react-bootstrap-table2-toolkit";
-import BootstrapTable from "react-bootstrap-table-next";
-import PaginationFactory from "react-bootstrap-table2-paginator";
+// import ToolkitProvider from "react-bootstrap-table2-toolkit";
+// import BootstrapTable from "react-bootstrap-table-next";
+// import PaginationFactory from "react-bootstrap-table2-paginator";
 import {faTrash} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
@@ -75,7 +75,7 @@ class DeleteUsersModal extends PureComponent {
                         </div>
                         <div className="modal-body">
                             <div className="table-result">
-                                <ToolkitProvider bootstrap4
+                                {/* <ToolkitProvider bootstrap4
                                                  columns={ this.columns}
                                                  data={ this.props.selectedUsers }
                                                  keyField="id">
@@ -88,7 +88,7 @@ class DeleteUsersModal extends PureComponent {
                                                                 pagination={ PaginationFactory({hideSizePerPage: true}) }/>
                                             </div>
                                         )}
-                                </ToolkitProvider>
+                                </ToolkitProvider> */}
                             </div>
                         </div>
                         <div className="modal-footer">

--- a/web/web-frontend/src/components/user/modal/DeleteUsersModal.js
+++ b/web/web-frontend/src/components/user/modal/DeleteUsersModal.js
@@ -17,9 +17,7 @@
 import React, {PureComponent} from "react";
 import axios from "axios";
 import validateErrorResponse from "../../../utility/HttpResponseValidator";
-// import ToolkitProvider from "react-bootstrap-table2-toolkit";
-// import BootstrapTable from "react-bootstrap-table-next";
-// import PaginationFactory from "react-bootstrap-table2-paginator";
+import DataTable from "../../utility/DataTable";
 import {faTrash} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
@@ -75,20 +73,13 @@ class DeleteUsersModal extends PureComponent {
                         </div>
                         <div className="modal-body">
                             <div className="table-result">
-                                {/* <ToolkitProvider bootstrap4
-                                                 columns={ this.columns}
-                                                 data={ this.props.selectedUsers }
-                                                 keyField="id">
-                                    {
-                                        (props) => (
-                                            <div>
-                                                <BootstrapTable { ...props.baseProps } bootstrap4 data={this.props.selectedUsers} columns={this.columns}
-                                                                defaultSorted={ this.defaultSort } keyField='id' hover
-                                                                striped
-                                                                pagination={ PaginationFactory({hideSizePerPage: true}) }/>
-                                            </div>
-                                        )}
-                                </ToolkitProvider> */}
+                                <DataTable
+                                    columns={this.columns}
+                                    data={this.props.selectedUsers}
+                                    keyField="id"
+                                    defaultSort={this.defaultSort}
+                                    pagination={{ hideSizePerPage: true }}
+                                ></DataTable>
                             </div>
                         </div>
                         <div className="modal-footer">

--- a/web/web-frontend/src/components/utility/DataTable.js
+++ b/web/web-frontend/src/components/utility/DataTable.js
@@ -28,6 +28,7 @@ import { memoize } from "underscore";
  * @property {string} text
  * @property {boolean} hidden
  * @property {(cell, row) => any} formatter
+ * @property {() => any} headerStyle
  * 
  * @typedef {object} DataTableData
  * 
@@ -136,7 +137,7 @@ class DataTable extends PureComponent {
                                 </th>
                             )}
                             {visibleColumns.map((column) => (
-                                <th key={column.dataField}>{column.text}</th>
+                                <th key={column.dataField} style={column.headerStyle?.() || {}}>{column.text}</th>
                             ))}
                         </tr>
                     </thead>

--- a/web/web-frontend/src/components/utility/DataTable.js
+++ b/web/web-frontend/src/components/utility/DataTable.js
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-import React, { PureComponent } from "react";
+import React, { PureComponent, createRef } from "react";
 import { FormCheck, Table, FormControl, Pagination } from "react-bootstrap";
 import { get, sortBy } from "underscore";
 import cn from "classnames";
@@ -107,6 +107,8 @@ class DataTable extends PureComponent {
             console.error("DataTable : 'keyField' prop is mandatory");
         }
 
+        this.selectAllCheckboxRef = createRef();
+
         this.state = {
             selectedKeys: new Set(),
             allSelected: false,
@@ -137,6 +139,7 @@ class DataTable extends PureComponent {
             selectedKeys: newSelectedKeys,
             allSelected: newAllSelected,
         });
+        this.selectAllCheckboxRef.current.indeterminate = newSelectedKeys.size > 0 && !newAllSelected;
         this.props.selectRow?.onSelect(row, selected);
     }
 
@@ -152,6 +155,7 @@ class DataTable extends PureComponent {
             selectedKeys: newSelectedKeys,
             allSelected: newAllSelected,
         });
+        this.selectAllCheckboxRef.current.indeterminate = newSelectedKeys.size > 0 && !newAllSelected;
         this.props.selectRow?.onSelectAll(newAllSelected);
     }
 
@@ -288,6 +292,7 @@ class DataTable extends PureComponent {
                                         inline
                                         checked={this.state.allSelected}
                                         onChange={() => this.onRowSelectAll()}
+                                        ref={this.selectAllCheckboxRef}
                                     ></FormCheck>
                                 </th>
                             )}

--- a/web/web-frontend/src/components/utility/DataTable.js
+++ b/web/web-frontend/src/components/utility/DataTable.js
@@ -50,6 +50,7 @@ const SORT_ORDER_CYCLE = new Map([
  * @typedef DTPagination
  * @property {number} sizePerPage
  * @property {number[]} sizePerPageList
+ * @property {boolean} hideSizePerPage
  *
  * @typedef {object} DTProps
  * @property {DTColumn[]} columns
@@ -188,7 +189,7 @@ class DataTable extends PureComponent {
 
     render() {
         const visibleColumns = this.props.columns.filter(column => !column.hidden);
-        const totalColumns = visibleColumns.length + (this.props.selectRow ? 1 : 0);
+        const numberOfColumns = visibleColumns.length + (this.props.selectRow ? 1 : 0);
         const filteredData = this.filterData(this.props.data);
         const sortedData = this.sortData(filteredData);
         const paginatedData = this.paginateData(sortedData);
@@ -203,7 +204,7 @@ class DataTable extends PureComponent {
                         onInput={this.onSearchInput}
                     ></FormControl>
                 }
-                <Table bordered striped>
+                <Table bordered striped hover>
                     <thead>
                         <tr>
                             {this.props.selectRow && (
@@ -236,11 +237,11 @@ class DataTable extends PureComponent {
                         {
                             this.props.data.length === 0 ? (
                                 <tr>
-                                    <td className="text-center" colSpan={totalColumns}>{this.props.noDataIndication}</td>
+                                    <td className="text-center" colSpan={numberOfColumns}>{this.props.noDataIndication}</td>
                                 </tr>
                             ) : paginatedData.length === 0 ? (
                                 <tr>
-                                    <td className="text-center" colSpan={totalColumns}>No search results</td>
+                                    <td className="text-center" colSpan={numberOfColumns}>No search results</td>
                                 </tr>
                             ) : (
                                 paginatedData.map((row) => {
@@ -273,20 +274,24 @@ class DataTable extends PureComponent {
                 </Table>
                 {
                     this.props.pagination && (
-                        <div className="d-flex justify-content-between">
-                            <FormControl
-                                as="select"
-                                className="w-auto"
-                                defaultValue={this.state.sizePerPage}
-                                onChange={this.onSizePerPageChange}
-                            >
-                                {
-                                    this.state.sizePerPageList.map((size) => (
-                                        <option value={size} key={size}>{size}</option>
-                                    ))
-                                }
-                            </FormControl>
-                            <Pagination>
+                        <div className="d-flex">
+                            {
+                                this.props.pagination.hideSizePerPage !== true && (
+                                    <FormControl
+                                        as="select"
+                                        className="w-auto mr-auto"
+                                        defaultValue={this.state.sizePerPage}
+                                        onChange={this.onSizePerPageChange}
+                                    >
+                                        {
+                                            this.state.sizePerPageList.map((size) => (
+                                                <option value={size} key={size}>{size}</option>
+                                            ))
+                                        }
+                                    </FormControl>
+                                )
+                            }
+                            <Pagination className="ml-auto">
                                 {
                                     Array.from({ length: numberOfPages }).map((_, pageIndex) => (
                                         <Pagination.Item

--- a/web/web-frontend/src/components/utility/DataTable.js
+++ b/web/web-frontend/src/components/utility/DataTable.js
@@ -16,7 +16,7 @@
 
 import React, { PureComponent } from "react";
 import { FormCheck, Table, FormControl, Pagination } from "react-bootstrap";
-import { sortBy } from "underscore";
+import { get, sortBy } from "underscore";
 import cn from "classnames";
 
 import "../../css/DataTable.css";
@@ -26,8 +26,8 @@ const SORT_ORDER_CYCLE = new Map([
     ["desc", "asc"],
     ["asc", "desc"]
 ]);
-const DEFAULT_SIZE_PER_PAGE = 5;
-const DEFAULT_SIZE_PER_PAGE_LIST = [5, 10, 20, 50];
+const DEFAULT_SIZE_PER_PAGE_LIST = [10, 25, 30, 50];
+const DEFAULT_SIZE_PER_PAGE = DEFAULT_SIZE_PER_PAGE_LIST[0];
 
 /**
  * Simple implementation of a Bootstrap Table with search, sorting and pagination capabilities.
@@ -248,7 +248,9 @@ class DataTable extends PureComponent {
                         {
                             !this.props.data?.length ? (
                                 <tr>
-                                    <td className="text-center" colSpan={numberOfColumns}>{this.props.noDataIndication}</td>
+                                    <td className="text-center" colSpan={numberOfColumns}>{
+                                        this.props.noDataIndication || "No data"
+                                    }</td>
                                 </tr>
                             ) : !paginatedData.length ? (
                                 <tr>
@@ -270,7 +272,8 @@ class DataTable extends PureComponent {
                                                 </td>
                                             )}
                                             {visibleColumns.map((column) => {
-                                                const cell = row[column.dataField];
+                                                const fieldPath = column.dataField.split(".");
+                                                const cell = get(row, fieldPath);
                                                 return (
                                                     <td key={column.dataField}>
                                                         {column.formatter ? column.formatter(cell, row) : cell}

--- a/web/web-frontend/src/components/utility/DataTable.js
+++ b/web/web-frontend/src/components/utility/DataTable.js
@@ -18,9 +18,16 @@ import React, { PureComponent } from "react";
 import FormCheck from "react-bootstrap/FormCheck";
 import Table from "react-bootstrap/Table";
 import FormControl from "react-bootstrap/FormControl"
-import { memoize } from "underscore";
+import cn from "classnames";
+import { sortBy } from "underscore";
 
 import "../../css/DataTable.css";
+
+const SORT_ORDER_CYCLE = new Map([
+    [undefined, "desc"],
+    ["desc", "asc"],
+    ["asc", "desc"]
+]);
 
 /**
  * Simple implementation of a Bootstrap Table with search, sorting and pagination capabilities.
@@ -29,10 +36,13 @@ import "../../css/DataTable.css";
  * @property {string} dataField
  * @property {string} text
  * @property {boolean} hidden
+ * @property {boolean} sort
  * @property {(cell, row) => any} formatter
  * @property {() => any} headerStyle
  * 
  * @typedef {object} DTData
+ * @typedef {"desc" | "asc" | undefined} DTOrder
+ * @typedef {{ dataField: DTColumn["dataField"], order: DTOrder }} DTColumnSort
  * 
  * @typedef DTSelectRow
  * @property {"checkbox"} mode
@@ -46,6 +56,7 @@ import "../../css/DataTable.css";
  * @property {string} noDataIndication
  * @property {boolean} search
  * @property {DTSelectRow} selectRow
+ * @property {DTColumnSort[]} defaultSort
  * 
  * @extends {PureComponent<DTProps>}
  */
@@ -56,11 +67,18 @@ class DataTable extends PureComponent {
         this.onRowSelect = this.onRowSelect.bind(this);
         this.onRowSelectAll = this.onRowSelectAll.bind(this);
         this.onSearchInput = this.onSearchInput.bind(this);
+        this.onColumnSort = this.onColumnSort.bind(this);
+        this.getFilteredData = this.getFilteredData.bind(this);
+
+        if (this.props.defaultSort?.length > 1) {
+            console.warn("DataTable : 'defaultSort' attribute doesn't (yet) support multiple columns");
+        }
 
         this.state = {
             selectedKeys: new Set(),
             allSelected: false,
             searchText: "",
+            columnSort: this.props.defaultSort?.slice(0, 1) || [],
         };
     }
 
@@ -99,17 +117,34 @@ class DataTable extends PureComponent {
         });
     }
 
-    getFilteredData = memoize(
-        (data, searchText) => {
-            return searchText
-                ? data.filter(row => this.props.columns
-                    .some(column => row[column.dataField]?.toLowerCase()?.includes(searchText)))
-                : data;
-        },
-        (data, searchText) => {
-            return data.map(row => row[this.props.keyField]).join(",") + "-" + searchText;
+    onColumnSort(column) {
+        if (!column.sort) {
+            return false;
         }
-    );
+        const currentSort = this.state.columnSort.find(sort => sort.dataField === column.dataField);
+        const newColumnSort = [{
+            dataField: column.dataField,
+            order: SORT_ORDER_CYCLE.get(currentSort?.order),
+        }];
+        this.setState({ columnSort: newColumnSort });
+    }
+
+    getFilteredData(data, searchText) {
+        let filtered = searchText
+            ? data.filter(row => this.props.columns
+                .some(column => row[column.dataField]?.toLowerCase()?.includes(searchText)))
+            : data;
+        const columnSort = this.state.columnSort[0];
+        if (columnSort) {
+            const fieldExtractor = (row) => row[columnSort.dataField]?.toLowerCase();
+            if (columnSort.order === "asc") {
+                filtered = sortBy(filtered, fieldExtractor);
+            } else if (columnSort.order === "desc") {
+                filtered = sortBy(filtered, fieldExtractor).reverse();
+            }
+        }
+        return filtered;
+    }
 
     render() {
         const visibleColumns = this.props.columns.filter(column => !column.hidden);
@@ -138,9 +173,20 @@ class DataTable extends PureComponent {
                                     ></FormCheck>
                                 </th>
                             )}
-                            {visibleColumns.map((column) => (
-                                <th key={column.dataField} style={column.headerStyle?.() || {}}>{column.text}</th>
-                            ))}
+                            {visibleColumns.map((column) => {
+                                const sort = this.state.columnSort.find(sort => sort.dataField === column.dataField);
+                                return (
+                                    <th
+                                        key={column.dataField}
+                                        style={column.headerStyle?.() || {}}
+                                        className={cn({ sortable: column.sort }, sort?.order)}
+                                        tabIndex={0}
+                                        onKeyUp={event => event.key === "Enter" && this.onColumnSort(column)}
+                                        onClick={() => this.onColumnSort(column)}
+                                    > {column.text}<span className="sort-icons"></span>
+                                    </th>
+                                )
+                            })}
                         </tr>
                     </thead>
                     <tbody>

--- a/web/web-frontend/src/components/utility/DataTable.js
+++ b/web/web-frontend/src/components/utility/DataTable.js
@@ -51,6 +51,8 @@ function getValue(row, dottedPath) {
  * @property {boolean} sort
  * @property {(cell, row) => any} formatter
  * @property {() => any} headerStyle
+ * @property {number} width
+ * @property {"left" | "center" | "right"} align
  * 
  * @typedef {object} DTData
  * @typedef {"desc" | "asc" | undefined} DTOrder
@@ -335,7 +337,10 @@ class DataTable extends PureComponent {
                                             {visibleColumns.map((column, columnIndex) => {
                                                 const cell = getValue(row, column.dataField);
                                                 return (
-                                                    <td key={columnIndex}>
+                                                    <td key={columnIndex} style={{
+                                                        width: column.width,
+                                                        textAlign: column.align,
+                                                    }}>
                                                         {column.formatter ? column.formatter(cell, row) : cell}
                                                     </td>
                                                 );

--- a/web/web-frontend/src/components/utility/DataTable.js
+++ b/web/web-frontend/src/components/utility/DataTable.js
@@ -1,5 +1,5 @@
 /*
- Copyright 2020 Karl Dahlgren
+ Copyright 2024 Karl Dahlgren
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -38,8 +38,12 @@ function getValue(row, dottedPath) {
 }
 
 /**
- * Simple implementation of a Bootstrap Table with search, sorting and pagination capabilities.
- * 
+ * Custom implementation of a Bootstrap Table component with search, sorting and
+ * pagination capabilities. This replaces the legacy package `react-bootstrap-table2`
+ * and uses almost the same prop names but does not implement all of its features.
+ *
+ * @see https://react-bootstrap-table.github.io/react-bootstrap-table2/
+ *
  * @typedef DTColumn
  * @property {string} dataField
  * @property {string} text
@@ -112,6 +116,11 @@ class DataTable extends PureComponent {
         };
     }
 
+    /**
+     * Handles a change in the selection state of a single row.
+     *
+     * @param {DTData} row Selected of unselected row
+     */
     onRowSelect(row) {
         const rowKey = row[this.props.keyField];
         const selected = !this.state.selectedKeys.has(rowKey);
@@ -129,6 +138,9 @@ class DataTable extends PureComponent {
         this.props.selectRow?.onSelect(row, selected);
     }
 
+    /**
+     * Handles a change in the selection state of all rows at once.
+     */
     onRowSelectAll() {
         const newAllSelected = !this.state.allSelected;
         const newSelectedKeys = newAllSelected
@@ -141,16 +153,26 @@ class DataTable extends PureComponent {
         this.props.selectRow?.onSelectAll(newAllSelected);
     }
 
-    onSearchInput(inputEvent) {
+    /**
+     * Handles change events in the search input.
+     *
+     * @param {Event} event Search input event
+     */
+    onSearchInput(event) {
         this.setState({
-            searchText: normalizeString(inputEvent.target.value),
+            searchText: normalizeString(event.target.value),
             currentPageIndex: 0,
         });
     }
 
+    /**
+     * Handles a change in the sort order of a column, if it is sortable.
+     *
+     * @param {DTColumn} column
+     */
     onColumnSort(column) {
         if (!column.sort) {
-            return false;
+            return;
         }
         const currentSort = this.state.columnSort.find(sort => sort.dataField === column.dataField);
         const newColumnSort = [{
@@ -160,6 +182,12 @@ class DataTable extends PureComponent {
         this.setState({ columnSort: newColumnSort });
     }
 
+    /**
+     * Filters a data array according to the value of the search input.
+     *
+     * @param {DTData[]} data The data array to filter
+     * @returns {DTData[]} The filtered data
+     */
     filterData(data) {
         let list = data;
         if (this.state.searchText) {
@@ -172,6 +200,12 @@ class DataTable extends PureComponent {
         return list;
     }
 
+    /**
+     * Sorts a data array according to the current column sort.
+     *
+     * @param {DTData[]} data The data array to sort
+     * @returns {DTData[]} The sorted data
+     */
     sortData(data) {
         let list = data;
         const columnSort = this.state.columnSort[0];
@@ -186,6 +220,12 @@ class DataTable extends PureComponent {
         return list;
     }
 
+    /**
+     * Slices the data array according to the current page index and sizePerPage.
+     *
+     * @param {DTData[]} data The data to paginate
+     * @returns {DTData[]} The paginated data
+     */
     paginateData(data) {
         let list = data;
         if (this.props.pagination) {
@@ -196,6 +236,11 @@ class DataTable extends PureComponent {
         return list;
     }
 
+    /**
+     * Handles a change in the number of element per page.
+     *
+     * @param {Event} event Change event
+     */
     onSizePerPageChange(event) {
         this.setState({
             sizePerPage: +event.target.value,
@@ -203,6 +248,11 @@ class DataTable extends PureComponent {
         });
     }
 
+    /**
+     * Handles a change of page.
+     *
+     * @param {number} pageIndex Index of the selected page
+     */
     onPageChange(pageIndex) {
         this.setState({
             currentPageIndex: pageIndex,
@@ -239,11 +289,11 @@ class DataTable extends PureComponent {
                                     ></FormCheck>
                                 </th>
                             )}
-                            {visibleColumns.map((column) => {
+                            {visibleColumns.map((column, columnIndex) => {
                                 const sort = this.state.columnSort.find(sort => sort.dataField === column.dataField);
                                 return (
                                     <th
-                                        key={column.dataField}
+                                        key={columnIndex}
                                         style={column.headerStyle?.() || {}}
                                         className={cn({ sortable: column.sort }, sort?.order)}
                                         tabIndex={0}
@@ -282,10 +332,10 @@ class DataTable extends PureComponent {
                                                     ></FormCheck>
                                                 </td>
                                             )}
-                                            {visibleColumns.map((column) => {
+                                            {visibleColumns.map((column, columnIndex) => {
                                                 const cell = getValue(row, column.dataField);
                                                 return (
-                                                    <td key={column.dataField}>
+                                                    <td key={columnIndex}>
                                                         {column.formatter ? column.formatter(cell, row) : cell}
                                                     </td>
                                                 );

--- a/web/web-frontend/src/components/utility/DataTable.js
+++ b/web/web-frontend/src/components/utility/DataTable.js
@@ -20,72 +20,74 @@ import Table from "react-bootstrap/Table";
 import FormControl from "react-bootstrap/FormControl"
 import { memoize } from "underscore";
 
+import "../../css/DataTable.css";
+
 /**
  * Simple implementation of a Bootstrap Table with search, sorting and pagination capabilities.
  * 
- * @typedef DataTableColumn
+ * @typedef DTColumn
  * @property {string} dataField
  * @property {string} text
  * @property {boolean} hidden
  * @property {(cell, row) => any} formatter
  * @property {() => any} headerStyle
  * 
- * @typedef {object} DataTableData
+ * @typedef {object} DTData
  * 
- * @typedef DataTableSelectRow
+ * @typedef DTSelectRow
  * @property {"checkbox"} mode
- * @property {(value: DataTableData, mode: boolean) => void} onSelect
+ * @property {(value: DTData, mode: boolean) => void} onSelect
  * @property {(mode: boolean) => void} onSelectAll
  * 
- * @typedef {object} DataTableProps
- * @property {DataTableColumn[]} columns
- * @property {DataTableData[]} data
+ * @typedef {object} DTProps
+ * @property {DTColumn[]} columns
+ * @property {DTData[]} data
  * @property {string} keyField
  * @property {string} noDataIndication
  * @property {boolean} search
- * @property {DataTableSelectRow} selectRow
+ * @property {DTSelectRow} selectRow
  * 
- * @extends {PureComponent<DataTableProps>}
+ * @extends {PureComponent<DTProps>}
  */
 class DataTable extends PureComponent {
 
     constructor(props) {
         super(props);
-        this.onRowSelect = this.onSelect.bind(this);
-        this.onSelectAll = this.onSelectAll.bind(this);
+        this.onRowSelect = this.onRowSelect.bind(this);
+        this.onRowSelectAll = this.onRowSelectAll.bind(this);
         this.onSearchInput = this.onSearchInput.bind(this);
 
         this.state = {
-            selectedIds: new Set(),
+            selectedKeys: new Set(),
             allSelected: false,
             searchText: "",
         };
     }
 
-    onSelect(row) {
-        const id = row[this.props.keyField];
-        const selected = !this.state.selectedIds.has(id);
-        const newSelectedIds = new Set(this.state.selectedIds);
+    onRowSelect(row) {
+        const rowKey = row[this.props.keyField];
+        const selected = !this.state.selectedKeys.has(rowKey);
+        const newSelectedKeys = new Set(this.state.selectedKeys);
         if (selected) {
-            newSelectedIds.add(id)
+            newSelectedKeys.add(rowKey)
         } else {
-            newSelectedIds.delete(id);
+            newSelectedKeys.delete(rowKey);
         }
-        const newAllSelected = newSelectedIds.size === this.props.data.length;
+        const newAllSelected = newSelectedKeys.size === this.props.data.length;
         this.setState({
-            selectedIds: newSelectedIds,
+            selectedKeys: newSelectedKeys,
             allSelected: newAllSelected,
         });
         this.props.selectRow.onSelect(row, selected);
     }
 
-    onSelectAll() {
+    onRowSelectAll() {
         const newAllSelected = !this.state.allSelected;
-        const newSelectedIds = newAllSelected
+        const newSelectedKeys = newAllSelected
             ? new Set(this.props.data.map(row => row[this.props.keyField]))
             : new Set();
         this.setState({
-            selectedIds: newSelectedIds,
+            selectedKeys: newSelectedKeys,
             allSelected: newAllSelected,
         });
         this.props.selectRow.onSelectAll(newAllSelected);
@@ -127,12 +129,12 @@ class DataTable extends PureComponent {
                     <thead>
                         <tr>
                             {this.props.selectRow && (
-                                <th style={{ width: 0 }} onClick={() => this.onSelectAll()}>
+                                <th style={{ width: 0 }} onClick={() => this.onRowSelectAll()}>
                                     <FormCheck
                                         className="m-0"
                                         inline
                                         checked={this.state.allSelected}
-                                        onChange={() => this.onSelectAll()}
+                                        onChange={() => this.onRowSelectAll()}
                                     ></FormCheck>
                                 </th>
                             )}
@@ -153,16 +155,16 @@ class DataTable extends PureComponent {
                                 </tr>
                             ) : (
                                 filteredData.map((row) => {
-                                    const rowId = row[this.props.keyField];
+                                    const rowKey = row[this.props.keyField];
                                     return (
-                                        <tr key={rowId}>
+                                        <tr key={rowKey}>
                                             {this.props.selectRow && (
-                                                <td style={{ width: 0 }} onClick={() => this.onSelect(row)}>
+                                                <td style={{ width: 0 }} onClick={() => this.onRowSelect(row)}>
                                                     <FormCheck
                                                         className="m-0"
                                                         inline
-                                                        checked={this.state.selectedIds.has(rowId)}
-                                                        onChange={() => this.onSelect(row)}
+                                                        checked={this.state.selectedKeys.has(rowKey)}
+                                                        onChange={() => this.onRowSelect(row)}
                                                     ></FormCheck>
                                                 </td>
                                             )}

--- a/web/web-frontend/src/components/utility/DataTable.js
+++ b/web/web-frontend/src/components/utility/DataTable.js
@@ -1,0 +1,156 @@
+/*
+ Copyright 2020 Karl Dahlgren
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import React, { PureComponent } from "react";
+import FormCheck from "react-bootstrap/FormCheck";
+import Table from "react-bootstrap/Table";
+import FormControl from "react-bootstrap/FormControl"
+
+/**
+ * Simple implementation of a Bootstrap Table with search, sorting and pagination capabilities.
+ * 
+ * @typedef DataTableColumn
+ * @property {string} dataField
+ * @property {string} text
+ * @property {boolean} hidden
+ * @property {(cell, row) => any} formatter
+ * 
+ * @typedef {object} DataTableData
+ * 
+ * @typedef DataTableSelectRow
+ * @property {"checkbox"} mode
+ * @property {(value: DataTableData, mode: boolean) => void} onSelect
+ * @property {(mode: boolean) => void} onSelectAll
+ * 
+ * @typedef {object} DataTableProps
+ * @property {DataTableColumn[]} columns
+ * @property {DataTableData[]} data
+ * @property {string} keyField
+ * @property {string} noDataIndication
+ * @property {boolean} search
+ * @property {DataTableSelectRow} selectRow
+ * 
+ * @extends {PureComponent<DataTableProps>}
+ */
+class DataTable extends PureComponent {
+
+    constructor(props) {
+        super(props);
+        this.onRowSelect = this.onSelect.bind(this);
+
+        this.state = {
+            selectedIds: new Set(),
+            allSelected: false,
+        };
+    }
+
+    onSelect(row) {
+        const id = row[this.props.keyField];
+        const selected = !this.state.selectedIds.has(id);
+        const newSelectedIds = new Set(this.state.selectedIds);
+        if (selected) {
+            newSelectedIds.add(id)
+        } else {
+            newSelectedIds.delete(id);
+        }
+        const newAllSelected = newSelectedIds.size === this.props.data.length;
+        this.setState({
+            selectedIds: newSelectedIds,
+            allSelected: newAllSelected,
+        });
+        this.props.selectRow.onSelect(row, selected);
+    }
+
+    onSelectAll() {
+        const newAllSelected = !this.state.allSelected;
+        const newSelectedIds = newAllSelected
+            ? new Set(this.props.data.map(row => row[this.props.keyField]))
+            : new Set();
+        this.setState({
+            selectedIds: newSelectedIds,
+            allSelected: newAllSelected,
+        });
+        this.props.selectRow.onSelectAll(newAllSelected);
+    }
+
+    render() {
+        const visibleColumns = this.props.columns.filter(column => !column.hidden);
+        const totalColumns = visibleColumns.length + (this.props.selectRow ? 1 : 0);
+
+        return (
+            <>
+                {
+                    this.props.search && <FormControl placeholder="Search" className="table-filter-field"></FormControl>
+                }
+                <Table bordered striped>
+                    <thead>
+                        <tr>
+                            {this.props.selectRow && (
+                                <th style={{ width: 0 }} onClick={() => this.onSelectAll()}>
+                                    <FormCheck
+                                        className="m-0"
+                                        inline
+                                        checked={this.state.allSelected}
+                                        onChange={() => this.onSelectAll()}
+                                    ></FormCheck>
+                                </th>
+                            )}
+                            {visibleColumns.map((column) => (
+                                <th key={column.dataField}>{column.text}</th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {
+                            this.props.data.length === 0 ? (
+                                <tr>
+                                    <td className="text-center" colSpan={totalColumns}>{this.props.noDataIndication}</td>
+                                </tr>
+                            ) : (
+                                this.props.data.map((row) => {
+                                    const rowId = row[this.props.keyField];
+                                    return (
+                                        <tr key={rowId}>
+                                            {this.props.selectRow && (
+                                                <td style={{ width: 0 }} onClick={() => this.onSelect(row)}>
+                                                    <FormCheck
+                                                        className="m-0"
+                                                        inline
+                                                        checked={this.state.selectedIds.has(rowId)}
+                                                        onChange={() => this.onSelect(row)}
+                                                    ></FormCheck>
+                                                </td>
+                                            )}
+                                            {visibleColumns.map((column) => {
+                                                const cell = row[column.dataField];
+                                                return (
+                                                    <td key={column.dataField}>
+                                                        {column.formatter ? column.formatter(cell, row) : cell}
+                                                    </td>
+                                                );
+                                            })}
+                                        </tr>
+                                    )
+                                })
+                            )}
+                    </tbody>
+                </Table>
+            </>
+        );
+    }
+}
+
+export default DataTable;

--- a/web/web-frontend/src/components/utility/DataTable.js
+++ b/web/web-frontend/src/components/utility/DataTable.js
@@ -29,6 +29,14 @@ const SORT_ORDER_CYCLE = new Map([
 const DEFAULT_SIZE_PER_PAGE_LIST = [10, 25, 30, 50];
 const DEFAULT_SIZE_PER_PAGE = DEFAULT_SIZE_PER_PAGE_LIST[0];
 
+function normalizeString(value) {
+    return value?.toString().toLowerCase() || ""
+}
+
+function getValue(row, dottedPath) {
+    return get(row, dottedPath.split("."));
+}
+
 /**
  * Simple implementation of a Bootstrap Table with search, sorting and pagination capabilities.
  * 
@@ -135,7 +143,7 @@ class DataTable extends PureComponent {
 
     onSearchInput(inputEvent) {
         this.setState({
-            searchText: inputEvent.target.value.toLowerCase(),
+            searchText: normalizeString(inputEvent.target.value),
             currentPageIndex: 0,
         });
     }
@@ -155,8 +163,11 @@ class DataTable extends PureComponent {
     filterData(data) {
         let list = data;
         if (this.state.searchText) {
-            list = list.filter(row => this.props.columns
-                ?.some(column => row[column.dataField]?.toLowerCase()?.includes(this.state.searchText)))
+            list = list.filter((row) => {
+                return this.props.columns?.some((column) => {
+                    return normalizeString(getValue(row, column.dataField)).includes(this.state.searchText)
+                });
+            });
         }
         return list;
     }
@@ -165,7 +176,7 @@ class DataTable extends PureComponent {
         let list = data;
         const columnSort = this.state.columnSort[0];
         if (columnSort) {
-            const fieldExtractor = (row) => row[columnSort.dataField]?.toLowerCase();
+            const fieldExtractor = (row) => normalizeString(getValue(row, columnSort.dataField));
             if (columnSort.order === "asc") {
                 list = sortBy(list, fieldExtractor);
             } else if (columnSort.order === "desc") {
@@ -272,8 +283,7 @@ class DataTable extends PureComponent {
                                                 </td>
                                             )}
                                             {visibleColumns.map((column) => {
-                                                const fieldPath = column.dataField.split(".");
-                                                const cell = get(row, fieldPath);
+                                                const cell = getValue(row, column.dataField);
                                                 return (
                                                     <td key={column.dataField}>
                                                         {column.formatter ? column.formatter(cell, row) : cell}

--- a/web/web-frontend/src/css/DataTable.css
+++ b/web/web-frontend/src/css/DataTable.css
@@ -1,0 +1,23 @@
+.table th.sortable {
+    cursor: pointer;
+    user-select: none;
+}
+
+.table th.sortable .sort-icons::before {
+    margin-left: 3.5px;
+    content: "\2191";
+    opacity: 0.4;
+}
+
+.table th.sortable .sort-icons::after {
+    content: "\2193";
+    opacity: 0.4;
+}
+
+.table th.sortable.asc .sort-icons::before {
+    opacity: 1;
+}
+
+.table th.sortable.desc .sort-icons::after {
+    opacity: 1;
+}

--- a/web/web-frontend/src/css/DataTable.css
+++ b/web/web-frontend/src/css/DataTable.css
@@ -22,6 +22,10 @@
     opacity: 1;
 }
 
+.table input[type="checkbox"] {
+    margin: 0 4px;
+}
+
 .pagination .visually-hidden {
     visibility: hidden;
     font-size: 0;

--- a/web/web-frontend/src/css/DataTable.css
+++ b/web/web-frontend/src/css/DataTable.css
@@ -21,3 +21,8 @@
 .table th.sortable.desc .sort-icons::after {
     opacity: 1;
 }
+
+.pagination .visually-hidden {
+    visibility: hidden;
+    font-size: 0;
+}

--- a/web/web-frontend/src/index.js
+++ b/web/web-frontend/src/index.js
@@ -15,9 +15,9 @@
  */
 
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import App from './components/App';
 import './css/index.css';
 
-ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+createRoot(document.getElementById('root')).render(<App />);

--- a/web/web-frontend/yarn.lock
+++ b/web/web-frontend/yarn.lock
@@ -3235,7 +3235,7 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz#6c370ab19f8a3394e318fe682686ec0ac684d107"
   integrity sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==
 
-classnames@^2.2.5, classnames@^2.3.2:
+classnames@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
   integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
@@ -4513,11 +4513,6 @@ file-loader@^6.2.0:
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
-
-file-saver@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.2.tgz#06d6e728a9ea2df2cce2f8d9e84dfcdc338ec17a"
-  integrity sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw==
 
 filelist@^1.0.4:
   version "1.0.4"
@@ -7530,32 +7525,6 @@ react-app-polyfill@^3.0.0:
     regenerator-runtime "^0.13.9"
     whatwg-fetch "^3.6.2"
 
-react-bootstrap-table-next@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/react-bootstrap-table-next/-/react-bootstrap-table-next-4.0.3.tgz#b55873b01adfe22a7181904b784a9d24ac2822cf"
-  integrity sha512-uKxC73qUdUfusRf2uzDfMiF9LvTG5vuhTZa0lbAgHWSLLLaKTsI0iHf1e4+c7gP71q8dFsp7StvkP65SxC1JRg==
-  dependencies:
-    classnames "^2.2.5"
-    react-transition-group "^4.2.0"
-    underscore "1.9.1"
-
-react-bootstrap-table2-filter@^1.1.6:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/react-bootstrap-table2-filter/-/react-bootstrap-table2-filter-1.3.3.tgz#ba189d137a2200b89f046041d0f4f307ce700623"
-  integrity sha512-lE+CHHGewzN9PCPaRqbu9wia8NMfwOBMPOAoAyfxbbMrZzjCf1WYRrHbWGzUj1MQlF5kJxLMwRgy/C604OmgMw==
-
-react-bootstrap-table2-paginator@^2.0.4:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/react-bootstrap-table2-paginator/-/react-bootstrap-table2-paginator-2.1.2.tgz#a62151909e594719db568cede6e5d2962cbf8ddb"
-  integrity sha512-LC5znEphhgKJvaSY1q8d+Gj0Nc/1X+VS3tKJjkmWmfv9P61YC/BnwJ+aoqEmQzsLiVGowrzss+i/u+Tip5H+Iw==
-
-react-bootstrap-table2-toolkit@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/react-bootstrap-table2-toolkit/-/react-bootstrap-table2-toolkit-2.1.3.tgz#554df765c3a4ab9d650b6686f55a5256e2509fab"
-  integrity sha512-nKBSezHTOkO9k8YMMuJfPEZtBVfIYrJbmP8n3u7+AXRcOrOGygXyauNVKWqdKLchQlG/cW5QR0sPkFknpp5rjQ==
-  dependencies:
-    file-saver "2.0.2"
-
 react-bootstrap@^2.9.1:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-2.9.2.tgz#ee2bab4cb19df628a90868fa594a3b410fe0c0be"
@@ -7725,7 +7694,7 @@ react-scripts@5.0.1:
   optionalDependencies:
     fsevents "^2.3.2"
 
-react-transition-group@^4.2.0, react-transition-group@^4.4.5:
+react-transition-group@^4.4.5:
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
   integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
@@ -8856,11 +8825,6 @@ underscore@1.13.6:
   version "1.13.6"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
-
-underscore@1.9.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
-  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Hi :smiley:  I noticed that the frontend of CastleMock wouldn't build anymore because the following packages haven't been updated for 4 years and are [not compatible with React 18](https://github.com/react-bootstrap-table/react-bootstrap-table2/issues/1765) : 
```
    "react-bootstrap-table-next": "^4.0.3",
    "react-bootstrap-table2-filter": "^1.1.6",
    "react-bootstrap-table2-paginator": "^2.0.4",
    "react-bootstrap-table2-toolkit": "^2.1.3",
```

As an exercice, I took a bit of time to drop theses dependencies and replace them with a custom DataTable component I built. I made it work with all the existing table configuration code and tried to make it look and behave the same way it did before. So it's almost a one-to-one replacement.

![image](https://github.com/castlemock/castlemock/assets/37326143/0184a52b-c4e0-4c07-a01d-9124e6d258aa)

I still have some BootstrapTable components left to replace and test (not the most difficult part). Please let me know if you are interested in merging this pull request once it is complete.