### PR TITLE
Extracted /mock/** endpoints into MockSecurityConfig.java which fixes basic authentication error

### DIFF
--- a/app/src/main/java/com/castlemock/app/config/MockSecurityConfig.java
+++ b/app/src/main/java/com/castlemock/app/config/MockSecurityConfig.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Karl Dahlgren
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.castlemock.app.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@Order(1)
+@EnableWebSecurity
+public class MockSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain mockSecurityFilterChain(final HttpSecurity http) throws Exception {
+        http
+                .securityMatcher("/mock/**")
+                .authorizeHttpRequests((authz) -> authz.requestMatchers("/mock/**").permitAll())
+                .csrf(AbstractHttpConfigurer::disable);
+        return http.build();
+    }
+
+}

--- a/app/src/main/java/com/castlemock/app/config/RestSecurityConfig.java
+++ b/app/src/main/java/com/castlemock/app/config/RestSecurityConfig.java
@@ -57,7 +57,7 @@ public class RestSecurityConfig {
     public SecurityFilterChain restSecurityFilterChain(final HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests((authz) -> authz.requestMatchers("/api/rest/core/login", "/api/rest/core/version",
-                                "/api/rest/core/context", "/doc/api/rest", "/mock/**")
+                                "/api/rest/core/context", "/doc/api/rest")
                         .permitAll()
                 ).authorizeHttpRequests((authz) -> authz.requestMatchers("/api/rest/**")
                         .authenticated()

--- a/deploy/deploy-tomcat/deploy-tomcat-jar/src/main/java/com/castlemock/deploy/tomcat/jar/config/JarTomcatApplication.java
+++ b/deploy/deploy-tomcat/deploy-tomcat-jar/src/main/java/com/castlemock/deploy/tomcat/jar/config/JarTomcatApplication.java
@@ -17,6 +17,7 @@
 package com.castlemock.deploy.tomcat.jar.config;
 
 import com.castlemock.app.config.Application;
+import com.castlemock.app.config.MockSecurityConfig;
 import com.castlemock.app.config.MvcConfig;
 import com.castlemock.app.config.PropertyConfig;
 import com.castlemock.app.config.RestSecurityConfig;
@@ -61,7 +62,7 @@ public class JarTomcatApplication extends Application implements WebApplicationI
     @Override
     protected SpringApplicationBuilder configure(final SpringApplicationBuilder application) {
         return application.sources(JarTomcatApplication.class, MvcConfig.class, SecurityConfig.class,
-                RestSecurityConfig.class, PropertyConfig.class, TomcatConfig.class);
+                MockSecurityConfig.class, RestSecurityConfig.class, PropertyConfig.class, TomcatConfig.class);
     }
 
     @Bean

--- a/deploy/deploy-tomcat/deploy-tomcat-war/src/main/java/com/castlemock/deploy/tomcat/war/config/WarTomcatApplication.java
+++ b/deploy/deploy-tomcat/deploy-tomcat-war/src/main/java/com/castlemock/deploy/tomcat/war/config/WarTomcatApplication.java
@@ -17,6 +17,7 @@
 package com.castlemock.deploy.tomcat.war.config;
 
 import com.castlemock.app.config.Application;
+import com.castlemock.app.config.MockSecurityConfig;
 import com.castlemock.app.config.MvcConfig;
 import com.castlemock.app.config.PropertyConfig;
 import com.castlemock.app.config.RestSecurityConfig;
@@ -57,7 +58,7 @@ public class WarTomcatApplication extends Application implements WebApplicationI
     @Override
     protected SpringApplicationBuilder configure(final SpringApplicationBuilder application) {
         return application.sources(WarTomcatApplication.class, MvcConfig.class, SecurityConfig.class,
-                RestSecurityConfig.class, PropertyConfig.class, TomcatConfig.class);
+                MockSecurityConfig.class, RestSecurityConfig.class, PropertyConfig.class, TomcatConfig.class);
     }
 
 }


### PR DESCRIPTION
This merge request should fix #793 and the solution is similar to what @karldahlgren already did in [8ce2e9f](https://github.com/castlemock/castlemock/commit/8ce2e9fc7557dee610defe5ac9802b510dfd8c58).